### PR TITLE
Add verify bundle functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-# VERSION defines the project version for the bundle.
+# BUNDLE_VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
-# - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
-# - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1
+# - use the BUNDLE_VERSION as arg of the bundle target (e.g make bundle BUNDLE_VERSION=0.0.2)
+# - use environment variables to overwrite this value (e.g export BUNDLE_VERSION=0.0.2)
+BUNDLE_VERSION ?= 0.0.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -28,12 +28,12 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # This variable is used to construct full image tags for bundle and catalog images.
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# openshift.io/aws-load-balancer-operator-bundle:$VERSION and openshift.io/aws-load-balancer-operator-catalog:$VERSION.
+# openshift.io/aws-load-balancer-operator-bundle:$BUNDLE_VERSION and openshift.io/aws-load-balancer-operator-catalog:$BUNDLE_VERSION.
 IMAGE_TAG_BASE ?= openshift.io/aws-load-balancer-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
+BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(BUNDLE_VERSION)
 
 # Image version to to build/push
 IMG_VERSION ?= latest
@@ -59,6 +59,8 @@ SHELL = /usr/bin/env bash -o pipefail
 
 # Use docker as the default container engine
 CONTAINER_ENGINE ?= docker
+
+OPERATOR_SDK_VERSION = v1.17.0
 
 .PHONY: all
 all: build
@@ -143,6 +145,19 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
+OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
+.PHONY: operator-sdk
+operator-sdk:
+ifeq (, $(shell which operator-sdk 2>/dev/null))
+	@{ \
+	set -e ;\
+	curl -Lk  https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_linux_amd64 > $(OPERATOR_SDK) ;\
+	chmod u+x $(OPERATOR_SDK) ;\
+	}
+else
+OPERATOR_SDK=$(shell which operator-sdk)
+endif
+
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
@@ -173,11 +188,11 @@ rm -rf $$TMP_DIR ;\
 endef
 
 .PHONY: bundle
-bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
-	operator-sdk generate kustomize manifests -q
+bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
+	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	operator-sdk bundle validate ./bundle
+	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite=false --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS)
+	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
@@ -209,7 +224,7 @@ endif
 BUNDLE_IMGS ?= $(BUNDLE_IMG)
 
 # The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
-CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(VERSION)
+CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(BUNDLE_VERSION)
 
 # Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
 ifneq ($(origin CATALOG_BASE_IMG), undefined)
@@ -232,3 +247,4 @@ verify:
 	hack/verify-deps.sh
 	hack/verify-generated.sh
 	hack/verify-gofmt.sh
+	hack/verify-bundle.sh

--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -116,7 +116,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: controller:latest
+                image: openshift.io/aws-load-balancer-operator:latest
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
+  newName: openshift.io/aws-load-balancer-operator
   newTag: latest

--- a/hack/verify-bundle.sh
+++ b/hack/verify-bundle.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function print_failure {
+  echo "There are unexpected changes to the tree when running 'make bundle'. Please"
+  echo "run these commands locally and double-check the Git repository for unexpected changes which may"
+  echo "need to be committed."
+  exit 1
+}
+
+if [ "${OPENSHIFT_CI:-false}" = true ]; then
+  echo "> generating the OLM bundle"
+  make bundle
+  git status
+  git diff
+  test -z "$(git status --porcelain | \grep -v '^??')" || print_failure
+fi


### PR DESCRIPTION
Added a script which verifies that the currently committed head is up-to-date. Also added this script to the `verify` target.

Also added a make target which installs the `operator-sdk` locally. And changed the environment variable name `$VERSION` to `$BUNDLE_VERSION` because it collides with the same environment variable in the build container.