### PR TITLE
Explicitly ensure the envtest assets directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,12 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet -mod=vendor ./...
 
+ENVTEST_ASSETS_DIR ?= $(shell pwd)/bin
+
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	mkdir -p "$(ENVTEST_ASSETS_DIR)"
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir "$(ENVTEST_ASSETS_DIR)")" go test -race ./... -coverprofile cover.out -covermode=atomic
 
 ##@ Build
 


### PR DESCRIPTION
The envtest requires certain binaries which are downloaded to a cache directory. In the CI environment this directory is not writeable. Instead the envtest can be instructed to use a directory within the repository where other binaries are also present.