### PR TITLE
Add function to ensure default IngressClass

### DIFF
--- a/api/v1alpha1/awsloadbalancercontroller_types.go
+++ b/api/v1alpha1/awsloadbalancercontroller_types.go
@@ -118,6 +118,12 @@ type AWSLoadBalancerControllerStatus struct {
 	// +kubebuilder:validation:Optional
 	// +optional
 	Subnets *AWSLoadBalancerControllerStatusSubnets `json:"subnets,omitempty"`
+
+	// IngressClass is the current default Ingress class.
+	//
+	// +kubebuilder:validation:Optional
+	// +optional
+	IngressClass string `json:"ingressClass,omitempty"`
 }
 
 type AWSLoadBalancerControllerStatusSubnets struct {

--- a/bundle/manifests/networking.olm.openshift.io_awsloadbalancercontrollers.yaml
+++ b/bundle/manifests/networking.olm.openshift.io_awsloadbalancercontrollers.yaml
@@ -154,6 +154,9 @@ spec:
                   - type
                   type: object
                 type: array
+              ingressClass:
+                description: IngressClass is the current default Ingress class.
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed.
                 format: int64

--- a/config/crd/bases/networking.olm.openshift.io_awsloadbalancercontrollers.yaml
+++ b/config/crd/bases/networking.olm.openshift.io_awsloadbalancercontrollers.yaml
@@ -155,6 +155,9 @@ spec:
                   - type
                   type: object
                 type: array
+              ingressClass:
+                description: IngressClass is the current default Ingress class.
+                type: string
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed.
                 format: int64

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -60,6 +61,7 @@ func init() {
 
 	utilruntime.Must(configv1.Install(scheme))
 	utilruntime.Must(cco.Install(scheme))
+	utilruntime.Must(networkingv1.AddToScheme(scheme))
 }
 
 func main() {

--- a/pkg/controllers/awsloadbalancercontroller/controller.go
+++ b/pkg/controllers/awsloadbalancercontroller/controller.go
@@ -84,6 +84,10 @@ func (r *AWSLoadBalancerControllerReconciler) Reconcile(ctx context.Context, req
 		}
 	}
 
+	if err := r.ensureIngressClass(ctx, lbController); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to ensure default IngressClass for AWSLoadBalancerController %s: %v", req, err)
+	}
+
 	if err := r.ensureCredentialsRequest(ctx, r.Namespace, lbController); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to ensure CredentialsRequest for AWSLoadBalancerController %s: %w", req, err)
 	}

--- a/pkg/controllers/awsloadbalancercontroller/ingressclass.go
+++ b/pkg/controllers/awsloadbalancercontroller/ingressclass.go
@@ -1,0 +1,65 @@
+package awsloadbalancercontroller
+
+import (
+	"context"
+	"fmt"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	albo "github.com/openshift/aws-load-balancer-operator/api/v1alpha1"
+)
+
+const (
+	albIngressClassController = "ingress.k8s.aws/alb"
+)
+
+// ensureIngressClass create the default IngressClass which is specified in the controller. This is required because the OpenShift router
+// reconciles any Ingress resource whose class is not defined or if the IngressClass does not have the spec.controllerName set.
+// Steps to ensure the IngressClass
+// 1. Check the status to see if the IngressClass already exists
+// 2. If the name matches then do nothing.
+// 3. If the name does not match then delete the existing IngressClass. Ignore if it doesn't exist.
+// 4. Create the new IngresClass with the correct controller name. If there is an AlreadyExists error, ignore it.
+// 5. Finally, update the status with the new IngressClass name.
+func (r *AWSLoadBalancerControllerReconciler) ensureIngressClass(ctx context.Context, controller *albo.AWSLoadBalancerController) error {
+
+	// if the current ingress class is the same then do nothing.
+	if controller.Status.IngressClass == controller.Spec.IngressClass {
+		return nil
+	}
+
+	// if the current ingress class name does not match then delete it.
+	if controller.Status.IngressClass != "" {
+		err := r.Delete(ctx, &networkingv1.IngressClass{ObjectMeta: metav1.ObjectMeta{Name: controller.Status.IngressClass}})
+		if err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete existing IngressClass %q: %w", controller.Status.IngressClass, err)
+		}
+	}
+
+	ingressClass := desiredIngressClass(controller.Spec.IngressClass)
+	err := controllerutil.SetOwnerReference(controller, ingressClass, r.Scheme)
+	if err != nil {
+		return fmt.Errorf("failed to set owner reference on new IngressClass %q: %w", ingressClass.Name, err)
+	}
+
+	err = r.Create(ctx, ingressClass)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create default IngressClass %s: %w", controller.Spec.IngressClass, err)
+	}
+	return r.updateStatusIngressClass(ctx, controller, controller.Spec.IngressClass)
+}
+
+func desiredIngressClass(name string) *networkingv1.IngressClass {
+	return &networkingv1.IngressClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: networkingv1.IngressClassSpec{
+			Controller: albIngressClassController,
+		},
+	}
+}

--- a/pkg/controllers/awsloadbalancercontroller/ingressclass_test.go
+++ b/pkg/controllers/awsloadbalancercontroller/ingressclass_test.go
@@ -1,0 +1,105 @@
+package awsloadbalancercontroller
+
+import (
+	"context"
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	albo "github.com/openshift/aws-load-balancer-operator/api/v1alpha1"
+)
+
+func TestDesiredIngressClass(t *testing.T) {
+	ic := desiredIngressClass("test")
+	if ic.Name != "test" {
+		t.Errorf("unexpected name in desired ingress class, expected %q, got %q", "test", ic.Name)
+	}
+	if ic.Spec.Controller != albIngressClassController {
+		t.Errorf("unexpected controller in desired ingress class, expected %q, got %q", albIngressClassController, ic.Spec.Controller)
+	}
+}
+
+func TestEnsureIngressClass(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		existingIngressClass *networkingv1.IngressClass
+		ingressClassName     string
+		deletedIngressClass  bool
+	}{
+		{
+			name:             "no existing ingress class",
+			ingressClassName: "new",
+		},
+		{
+			name:                 "existing ingress class",
+			existingIngressClass: desiredIngressClass("old"),
+			ingressClassName:     "new",
+			deletedIngressClass:  true,
+		},
+		{
+			name:                 "existing ingress class, name no change",
+			existingIngressClass: desiredIngressClass("old"),
+			ingressClassName:     "old",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var existingObjects []client.Object
+			if tc.existingIngressClass != nil {
+				existingObjects = append(existingObjects, tc.existingIngressClass)
+			}
+			controller := &albo.AWSLoadBalancerController{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: albo.AWSLoadBalancerControllerSpec{
+					IngressClass: tc.ingressClassName,
+				},
+			}
+			if tc.existingIngressClass != nil {
+				controller.Status.IngressClass = tc.existingIngressClass.Name
+			}
+			existingObjects = append(existingObjects, controller)
+			testClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingObjects...).Build()
+			r := &AWSLoadBalancerControllerReconciler{
+				Scheme: scheme,
+				Client: testClient,
+			}
+			err := r.ensureIngressClass(context.Background(), controller)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			var ingressClass networkingv1.IngressClass
+			err = testClient.Get(context.Background(), types.NamespacedName{Name: tc.ingressClassName}, &ingressClass)
+			if err != nil {
+				t.Fatalf("failed to get ingress class %q: %v", tc.ingressClassName, err)
+			}
+			if ingressClass.Spec.Controller != albIngressClassController {
+				t.Errorf("IngressClass does not have correct controller name, expected %q, got %q", albIngressClassController, ingressClass.Spec.Controller)
+			}
+			if tc.deletedIngressClass {
+				var ic networkingv1.IngressClass
+				err = r.Get(context.Background(), types.NamespacedName{Name: tc.existingIngressClass.Name}, &ic)
+				if err != nil && !errors.IsNotFound(err) {
+					t.Errorf("failed to get ingress class %q: %v", tc.existingIngressClass.Name, err)
+					return
+				}
+				if err == nil {
+					t.Errorf("existing ingress class %q was not deleted", tc.existingIngressClass.Name)
+				}
+			}
+			err = r.Get(context.Background(), types.NamespacedName{Name: "test"}, controller)
+			if err != nil {
+				t.Errorf("failed to get controller: %v", err)
+				return
+			}
+			if controller.Status.IngressClass != tc.ingressClassName {
+				t.Errorf("status of controller does not have correct ingress class, expected %q, got %q", tc.ingressClassName, controller.Status.IngressClass)
+			}
+		})
+	}
+}

--- a/pkg/controllers/awsloadbalancercontroller/status.go
+++ b/pkg/controllers/awsloadbalancercontroller/status.go
@@ -65,3 +65,14 @@ func equalStrings(x1, x2 []string) bool {
 	sort.Strings(x2c)
 	return cmp.Equal(x1c, x2c)
 }
+
+func (r *AWSLoadBalancerControllerReconciler) updateStatusIngressClass(ctx context.Context, controller *albo.AWSLoadBalancerController, ingressClass string) error {
+
+	if controller.Status.IngressClass == ingressClass {
+		return nil
+	}
+
+	updated := controller.DeepCopy()
+	updated.Status.IngressClass = ingressClass
+	return r.Status().Update(ctx, updated)
+}

--- a/pkg/controllers/awsloadbalancercontroller/subnettagging_test.go
+++ b/pkg/controllers/awsloadbalancercontroller/subnettagging_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,6 +38,7 @@ func init() {
 
 	utilruntime.Must(configv1.Install(scheme))
 	utilruntime.Must(cco.Install(scheme))
+	utilruntime.Must(networkingv1.AddToScheme(scheme))
 }
 
 func TestClassifySubnet(t *testing.T) {


### PR DESCRIPTION
The default `IngressClass` for the controller should be ensured by the operator. The OpenShift router reconciles all Ingress resources whose `IngressClass` is undefined. It does not reconcile only those _Ingress_ resources whose `IngressClass` is defined and the controller does not match it's own controller value. So the `IngressClass` must be instantiated to prevent the router and the controller from attempting to reconcile the same Ingress.