### PR TITLE
Fixes naming issue in credentials request

### DIFF
--- a/pkg/controllers/awsloadbalancercontroller/credentials_request.go
+++ b/pkg/controllers/awsloadbalancercontroller/credentials_request.go
@@ -48,7 +48,7 @@ func (r *AWSLoadBalancerControllerReconciler) ensureCredentialsRequest(ctx conte
 		return nil, fmt.Errorf("failed to get existing credentials request %q: %w", credReq.Name, err)
 	}
 
-	credentialRequestSecretName := fmt.Sprintf("%s-credentialsRequest-%s", controllerResourcePrefix, controller.Name)
+	credentialRequestSecretName := fmt.Sprintf("%s-credentialsrequest-%s", controllerResourcePrefix, controller.Name)
 
 	// The secret created will be in the operator namespace.
 	secretRef := createCredentialsSecretRef(credentialRequestSecretName, namespace)

--- a/pkg/controllers/awsloadbalancercontroller/credentials_request_test.go
+++ b/pkg/controllers/awsloadbalancercontroller/credentials_request_test.go
@@ -109,7 +109,7 @@ func TestEnsureCredentialsRequest(t *testing.T) {
 				t.Fatalf("error expected but not received")
 			}
 
-			expectedSecretName := fmt.Sprintf("%s-credentialsRequest-%s", controllerResourcePrefix, "cluster")
+			expectedSecretName := fmt.Sprintf("%s-credentialsrequest-%s", controllerResourcePrefix, "cluster")
 			if cr.Spec.SecretRef.Name != expectedSecretName {
 				t.Errorf("unexpected CredentialsRequest secret name, expected %q, got %q", expectedSecretName, cr.Spec.SecretRef.Name)
 			}
@@ -152,7 +152,7 @@ func testCompleteCredentialsRequest() *cco.CredentialsRequest {
 		},
 		Spec: cco.CredentialsRequestSpec{
 			ProviderSpec: cfg,
-			SecretRef:    createCredentialsSecretRef("aws-load-balancer-controller-credentialsRequest-cluster", test.OperatorNamespace),
+			SecretRef:    createCredentialsSecretRef("aws-load-balancer-controller-credentialsrequest-cluster", test.OperatorNamespace),
 		},
 	}
 }


### PR DESCRIPTION
Fixes 
```
    message: 'failed to grant creds: error syncing creds in mint-mode: Secret "aws-load-balancer-controller-credentialsRequest-cluster"
      is invalid: metadata.name: Invalid value: "aws-load-balancer-controller-credentialsRequest-cluster":
      a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters,
      ''-'' or ''.'', and must start and end with an alphanumeric character (e.g.
      ''example.com'', regex used for validation is ''[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'')'

```