### PR TITLE
Enable gosec linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -74,6 +74,7 @@ linters:
     - errcheck
     - gofmt
     - goimports
+    - gosec
     - gosimple
     - govet
     - ineffassign
@@ -90,5 +91,8 @@ linters-settings:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
     local-prefixes: github.com/openshift/aws-load-balancer-operator
+  gosec:
+    excludes:
+      - G101
 
 


### PR DESCRIPTION
This change enables the gosec linter but disables the rule for hardcoded credentials which yields many false positives.