### PR TITLE
Parameterize the operand image

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -137,14 +137,6 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - secrets
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
-          - ""
-          resources:
           - services
           verbs:
           - get
@@ -424,6 +416,8 @@ spec:
                 env:
                 - name: AWS_SHARED_CREDENTIALS_FILE
                   value: /etc/aws-credentials/credentials
+                - name: RELATED_IMAGE_CONTROLLER
+                  value: docker.io/amazon/aws-alb-ingress-controller:v2.4.1
                 image: openshift.io/aws-load-balancer-operator:latest
                 livenessProbe:
                   httpGet:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,6 +31,7 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - --image=$(RELATED_IMAGE_CONTROLLER)
         image: controller:latest
         name: manager
         securityContext:
@@ -59,6 +60,8 @@ spec:
         env:
           - name: AWS_SHARED_CREDENTIALS_FILE
             value: /etc/aws-credentials/credentials
+          - name: RELATED_IMAGE_CONTROLLER
+            value: docker.io/amazon/aws-alb-ingress-controller:v2.4.1
         volumeMounts:
           - mountPath: /etc/aws-credentials
             name: aws-credentials

--- a/config/rbac/upstream_role.yaml
+++ b/config/rbac/upstream_role.yaml
@@ -55,14 +55,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - services
   verbs:
   - get


### PR DESCRIPTION
The operand image can be passed as a parameter to the operator. This change adds the image as a environment variable which is copied to the CLI.