### PR TITLE
Set the AWSLoadBalancerController as the controller resource

### DIFF
--- a/pkg/controllers/awsloadbalancercontroller/credentials_request.go
+++ b/pkg/controllers/awsloadbalancercontroller/credentials_request.go
@@ -58,7 +58,7 @@ func (r *AWSLoadBalancerControllerReconciler) ensureCredentialsRequest(ctx conte
 		return nil, fmt.Errorf("failed to build desired credentials request: %w", err)
 	}
 
-	err = controllerutil.SetOwnerReference(controller, desired, r.Scheme)
+	err = controllerutil.SetControllerReference(controller, desired, r.Scheme)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set owner reference on desired credentials request: %w", err)
 	}

--- a/pkg/controllers/awsloadbalancercontroller/deployment.go
+++ b/pkg/controllers/awsloadbalancercontroller/deployment.go
@@ -52,7 +52,7 @@ func (r *AWSLoadBalancerControllerReconciler) ensureDeployment(ctx context.Conte
 	}
 
 	desired := desiredDeployment(deploymentName, namespace, image, r.VPCID, r.ClusterName, r.AWSRegion, crSecretName, servingSecretName, controller, sa)
-	err = controllerutil.SetOwnerReference(controller, desired, r.Scheme)
+	err = controllerutil.SetControllerReference(controller, desired, r.Scheme)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set owner reference on deployment %s: %w", deploymentName, err)
 	}

--- a/pkg/controllers/awsloadbalancercontroller/deployment_test.go
+++ b/pkg/controllers/awsloadbalancercontroller/deployment_test.go
@@ -182,12 +182,14 @@ func (b *testDeploymentBuilder) withContainers(containers ...corev1.Container) *
 	return b
 }
 
-func (b *testDeploymentBuilder) withOwnerReference(name string) *testDeploymentBuilder {
+func (b *testDeploymentBuilder) withControllerReference(name string) *testDeploymentBuilder {
 	b.ownerReference = []metav1.OwnerReference{
 		{
-			APIVersion: albo.GroupVersion.Identifier(),
-			Kind:       "AWSLoadBalancerController",
-			Name:       name,
+			APIVersion:         albo.GroupVersion.Identifier(),
+			Kind:               "AWSLoadBalancerController",
+			Name:               name,
+			Controller:         pointer.BoolPtr(true),
+			BlockOwnerDeletion: pointer.BoolPtr(true),
 		},
 	}
 	return b
@@ -559,7 +561,7 @@ func TestEnsureDeployment(t *testing.T) {
 					corev1.VolumeMount{Name: "aws-credentials", MountPath: "/aws"},
 					corev1.VolumeMount{Name: "tls", MountPath: "/tls"},
 				).build(),
-			).withOwnerReference("cluster").withVolumes(
+			).withControllerReference("cluster").withVolumes(
 				corev1.Volume{Name: "aws-credentials", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-credentials"}}},
 				corev1.Volume{Name: "tls", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-serving"}}},
 			).build(),

--- a/pkg/controllers/awsloadbalancercontroller/ingressclass.go
+++ b/pkg/controllers/awsloadbalancercontroller/ingressclass.go
@@ -40,7 +40,7 @@ func (r *AWSLoadBalancerControllerReconciler) ensureIngressClass(ctx context.Con
 	}
 
 	ingressClass := desiredIngressClass(controller.Spec.IngressClass)
-	err := controllerutil.SetOwnerReference(controller, ingressClass, r.Scheme)
+	err := controllerutil.SetControllerReference(controller, ingressClass, r.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to set owner reference on new IngressClass %q: %w", ingressClass.Name, err)
 	}

--- a/pkg/controllers/awsloadbalancercontroller/service.go
+++ b/pkg/controllers/awsloadbalancercontroller/service.go
@@ -30,7 +30,7 @@ func (r *AWSLoadBalancerControllerReconciler) ensureService(ctx context.Context,
 	}
 
 	desired := desiredService(serviceName.Name, serviceName.Namespace, servingSecretName, deployment.Spec.Selector.MatchLabels)
-	err := controllerutil.SetOwnerReference(controller, desired, r.Scheme)
+	err := controllerutil.SetControllerReference(controller, desired, r.Scheme)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set owner reference on desired service: %w", err)
 	}

--- a/pkg/controllers/awsloadbalancercontroller/webhooks.go
+++ b/pkg/controllers/awsloadbalancercontroller/webhooks.go
@@ -32,7 +32,7 @@ func (r *AWSLoadBalancerControllerReconciler) ensureWebhooks(ctx context.Context
 	reqLogger.Info("ensuring validating and mutating webhook configurations for aws-load-balancer-controller instance")
 
 	desiredVWC := desiredValidatingWebhookConfiguration(controller, service)
-	err := controllerutil.SetOwnerReference(controller, desiredVWC, r.Scheme)
+	err := controllerutil.SetControllerReference(controller, desiredVWC, r.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to set owner reference on desired ValidatingWebhookConfiguration %q: %w", desiredVWC.Name, err)
 	}
@@ -56,7 +56,7 @@ func (r *AWSLoadBalancerControllerReconciler) ensureWebhooks(ctx context.Context
 	}
 
 	desiredMWC := desiredMutatingWebhookConfiguration(controller, service)
-	err = controllerutil.SetOwnerReference(controller, desiredMWC, r.Scheme)
+	err = controllerutil.SetControllerReference(controller, desiredMWC, r.Scheme)
 	if err != nil {
 		return fmt.Errorf("failed to set owner reference on desired MutatingWebhookConfiguration %q: %w", desiredMWC.Name, err)
 	}


### PR DESCRIPTION
Changes to the operand resources are only reconciled through the owning resource if the owning resource is marked as the controller. So instead of setting the `AWSLoadBalancerController` as just an owner the controller field should also be set to true.

Reference: https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.2/pkg/builder#Builder.Owns