### PR TITLE
Patch the target namespace annotation only for the bundle

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -68,7 +68,7 @@ spec:
           - name: TARGET_NAMESPACE
             valueFrom:
               fieldRef:
-                fieldPath: metadata.annotations['olm.targetNamespaces']
+                fieldPath: metadata.namespace
         volumeMounts:
           - mountPath: /etc/aws-credentials
             name: aws-credentials

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -24,3 +24,18 @@ resources:
 #    # Update the indices in this path if adding or removing volumes in the manager's Deployment.
 #    - op: remove
 #      path: /spec/template/spec/volumes/0
+
+# This patch sets the TARGET_NAMESPACE environment variable to the annotation which is added by the OLM.
+patchesJson6902:
+  - target:
+      kind: Deployment
+      name: controller-manager
+      version: v1
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/1/env/2
+        value: 
+          name: TARGET_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['olm.targetNamespaces']


### PR DESCRIPTION
The `olm.targetNamespaces` annotation is only present on the pod when the deployment is created by the OLM. So when deploying the operator the `TARGET_NAMESPACE` should default to the operator namespace and when deployed through an operator bundle should be taken from the annotation.