### PR TITLE
Add annotations for osbs bundle build

### DIFF
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -8,3 +8,7 @@ annotations:
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.16.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+  # should this operator be supported on OCP 4.4 and earlier (old appregistry format)
+  com.redhat.delivery.backport: false
+  # this is a bundle image and should be delivered via an index image
+  com.redhat.delivery.operator.bundle: true


### PR DESCRIPTION
These annotations will be copied into the midstream image file and then be used by [osbs](https://osbs.readthedocs.io/en/latest/users.html?highlight=operator_manifests#operator-manifests) when building the operator bundle image.