### PR TITLE
Set securityContext for operator pods

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -279,6 +279,10 @@ spec:
                   requests:
                     cpu: 5m
                     memory: 64Mi
+                securityContext:
+                  capabilities:
+                    drop:
+                    - ALL
               - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
@@ -319,11 +323,16 @@ spec:
                     memory: 64Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
                 volumeMounts:
                 - mountPath: /etc/aws-credentials
                   name: aws-credentials
               securityContext:
                 runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
               serviceAccountName: aws-load-balancer-operator-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -20,6 +20,10 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        securityContext:
+          capabilities:
+            drop:
+              - ALL
         resources:
           limits:
             cpu: 500m

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,6 +26,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -39,6 +41,9 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Explicitly set the [seccompProfile](https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads) for the operator pod and drop all [capabilities](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container) in the operator and proxy containers.

/assign @thejasn 
/label px-approved
/label docs-approved
/label qe-approved