### PR TITLE
Fix security context of kube-proxy

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -283,6 +283,7 @@ spec:
                     cpu: 5m
                     memory: 64Mi
                 securityContext:
+                  allowPrivilegeEscalation: false
                   capabilities:
                     drop:
                     - ALL

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -21,6 +21,7 @@ spec:
           protocol: TCP
           name: https
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             drop:
               - ALL


### PR DESCRIPTION
Fix security context of kube-proxy
---
Fixes
`
Warning: would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "kube-rbac-proxy" must set securityContext.allowPrivilegeEscalation=false)
`

Signed-off-by: thejasn <thn@redhat.com>