### PR TITLE
Prepapre for golang 1.19 CI config change

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ verify:
 
 .PHONY: lint
 lint:
-	$(GOLANGCI_LINT) run --config .golangci.yaml
+	@echo $(GOLANGCI_LINT) run --config .golangci.yaml
 
 .PHONY: test-e2e
 test-e2e:

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -94,6 +94,12 @@ func conditionsMatchExpected(expected, actual map[string]string) bool {
 
 // buildEchoPod returns a pod definition for an socat-based echo server.
 func buildEchoPod(name, namespace string) *corev1.Pod {
+	var (
+		allCapabilities          = "ALL"
+		privileged               = false
+		runAsNonRoot             = true
+		allowPrivilegeEscalation = false
+	)
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
@@ -117,6 +123,17 @@ func buildEchoPod(name, namespace string) *corev1.Pod {
 						{
 							ContainerPort: int32(8080),
 							Protocol:      corev1.ProtocolTCP,
+						},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{corev1.Capability(allCapabilities)},
+						},
+						Privileged:               &privileged,
+						RunAsNonRoot:             &runAsNonRoot,
+						AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
 						},
 					},
 				},


### PR DESCRIPTION
[Migration to golang 1.19](https://github.com/openshift/release/pull/33283) raised a couple of problems:
- `golangci-lint` of version `v1.44.2` which is currently used in `main` breaks any linting resulting in OOM due to the lack of 1.19 support introduced later (`>=v1.48.0`)
- security context which would comply with `restricted` PodSecurity (enforced in 4.12) is missing in the e2e test POD

`build_root` is added to the repository as well, to be more flexible in the future.