### PR TITLE
operator needs projected token for STS credentials

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -333,6 +333,9 @@ spec:
                 volumeMounts:
                 - mountPath: /etc/aws-credentials
                   name: aws-credentials
+                - mountPath: /var/run/secrets/openshift/serviceaccount
+                  name: bound-sa-token
+                  readOnly: true
               securityContext:
                 runAsNonRoot: true
                 seccompProfile:
@@ -346,6 +349,14 @@ spec:
                   - key: credentials
                     path: credentials
                   secretName: aws-load-balancer-operator
+              - name: bound-sa-token
+                projected:
+                  defaultMode: 420
+                  sources:
+                  - serviceAccountToken:
+                      audience: openshift
+                      expirationSeconds: 3600
+                      path: token
       permissions:
       - rules:
         - apiGroups:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,6 +77,9 @@ spec:
         volumeMounts:
           - mountPath: /etc/aws-credentials
             name: aws-credentials
+          - name: bound-sa-token
+            mountPath: /var/run/secrets/openshift/serviceaccount
+            readOnly: true
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
@@ -86,3 +89,11 @@ spec:
             items:
               - key: credentials
                 path: credentials
+        - name: bound-sa-token
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                audience: openshift
+                expirationSeconds: 3600
+                path: token


### PR DESCRIPTION
This is related to #77 

{"error": "failed to list VPC with tag "kubernetes.io/cluster/${cluster_name}": operation error EC2: DescribeVpcs, failed to sign request: failed to retrieve credentials: failed to refresh cached credentials, failed to retrieve jwt from provide source, unable to read file at /var/run/secrets/openshift/serviceaccount/token: open /var/run/secrets/openshift/serviceaccount/token: no such file or directory"}

The operator( Not the controller) in STS mode requires the projected token. However, the token is not configured