### PR TITLE
CFE-648: Upgrade aws load balancer controller to v2.4.4

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -299,7 +299,7 @@ spec:
                 - name: AWS_SHARED_CREDENTIALS_FILE
                   value: /etc/aws-credentials/credentials
                 - name: RELATED_IMAGE_CONTROLLER
-                  value: docker.io/amazon/aws-alb-ingress-controller:v2.4.4
+                  value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:95d71cc4e7e594fd7cca52c5904c3cf86837bf1e90955eecee6b5cd0862eb501
                 - name: TARGET_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -299,7 +299,7 @@ spec:
                 - name: AWS_SHARED_CREDENTIALS_FILE
                   value: /etc/aws-credentials/credentials
                 - name: RELATED_IMAGE_CONTROLLER
-                  value: docker.io/amazon/aws-alb-ingress-controller:v2.4.1
+                  value: docker.io/amazon/aws-alb-ingress-controller:v2.4.4
                 - name: TARGET_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,7 +69,7 @@ spec:
           - name: AWS_SHARED_CREDENTIALS_FILE
             value: /etc/aws-credentials/credentials
           - name: RELATED_IMAGE_CONTROLLER
-            value: docker.io/amazon/aws-alb-ingress-controller:v2.4.4
+            value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:95d71cc4e7e594fd7cca52c5904c3cf86837bf1e90955eecee6b5cd0862eb501
           - name: TARGET_NAMESPACE
             valueFrom:
               fieldRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,7 +69,7 @@ spec:
           - name: AWS_SHARED_CREDENTIALS_FILE
             value: /etc/aws-credentials/credentials
           - name: RELATED_IMAGE_CONTROLLER
-            value: docker.io/amazon/aws-alb-ingress-controller:v2.4.1
+            value: docker.io/amazon/aws-alb-ingress-controller:v2.4.4
           - name: TARGET_NAMESPACE
             valueFrom:
               fieldRef:

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	k8s.io/apimachinery v0.25.3
 	k8s.io/client-go v0.25.3
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
-	sigs.k8s.io/aws-load-balancer-controller v0.0.0-20220316010148-c4471defda10
+	sigs.k8s.io/aws-load-balancer-controller v0.0.0-20220923211742-8d282339857c
 	sigs.k8s.io/controller-runtime v0.13.0
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20220407132358-188b48630db2
 	sigs.k8s.io/controller-tools v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -1346,8 +1346,8 @@ mvdan.cc/unparam v0.0.0-20220706161116-678bad134442/go.mod h1:F/Cxw/6mVrNKqrR2Yj
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
-sigs.k8s.io/aws-load-balancer-controller v0.0.0-20220316010148-c4471defda10 h1:k00CjF5xvSxbAlzjITqh8rSKP8w0a4DiK6NtCYCfoks=
-sigs.k8s.io/aws-load-balancer-controller v0.0.0-20220316010148-c4471defda10/go.mod h1:IgdiNk6qx80CRWsvY2tfmXrpxG6rhkb9p+8oTcaJXzs=
+sigs.k8s.io/aws-load-balancer-controller v0.0.0-20220923211742-8d282339857c h1:fBqIqHt15N77DumArx4WM1oQijcwhn15t8jmdUqL4qE=
+sigs.k8s.io/aws-load-balancer-controller v0.0.0-20220923211742-8d282339857c/go.mod h1:Qc8eLv+CH8uM731hIWfFjYVx7rl36+JobbOhP1TAA5U=
 sigs.k8s.io/controller-runtime v0.13.0 h1:iqa5RNciy7ADWnIc8QxCbOX5FEKVR3uxVxKHRMc2WIQ=
 sigs.k8s.io/controller-runtime v0.13.0/go.mod h1:Zbz+el8Yg31jubvAEyglRZGdLAjplZl+PgtYNI6WNTI=
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20220407132358-188b48630db2 h1:Aeremz8m2nQFqy9VMRPSlHhdJMIzKJJLLJSWnMIGEog=

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&namespace, "namespace", "aws-load-balancer-operator", "The namespace where operands should be installed")
-	flag.StringVar(&image, "image", "docker.io/amazon/aws-alb-ingress-controller:v2.4.1", "The image to be used for the operand")
+	flag.StringVar(&image, "image", "quay.io/aws-load-balancer-operator/aws-load-balancer-controller:latest", "The image to be used for the operand")
 	opts := zap.Options{
 		Development: true,
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1463,8 +1463,8 @@ mvdan.cc/lint
 # mvdan.cc/unparam v0.0.0-20220706161116-678bad134442
 ## explicit; go 1.17
 mvdan.cc/unparam/check
-# sigs.k8s.io/aws-load-balancer-controller v0.0.0-20220316010148-c4471defda10
-## explicit; go 1.17
+# sigs.k8s.io/aws-load-balancer-controller v0.0.0-20220923211742-8d282339857c
+## explicit; go 1.18
 sigs.k8s.io/aws-load-balancer-controller/apis/elbv2/v1beta1
 # sigs.k8s.io/controller-runtime v0.13.0
 ## explicit; go 1.17


### PR DESCRIPTION
Description
---

Bumps aws-load-balancer-controller to `v2.4.4` and the corresponding default controller image  to `quay.io/aws-load-balancer-operator/aws-load-balancer-controller:95d71cc4e7e5` (pins to https://github.com/openshift/aws-load-balancer-controller/tree/2c04703264566be3608cbbf4145929b549fe320a).

Docs and Release notes: https://github.com/openshift/openshift-docs/pull/52292, https://github.com/openshift/openshift-docs/pull/52309