### PR TITLE
CFE-649: Disable ip target type on Service and Ingress resources

### DIFF
--- a/pkg/controllers/awsloadbalancercontroller/deployment.go
+++ b/pkg/controllers/awsloadbalancercontroller/deployment.go
@@ -243,6 +243,7 @@ func desiredContainerArgs(controller *albo.AWSLoadBalancerController, clusterNam
 		args = append(args, "--enable-wafv2=false")
 	}
 	args = append(args, fmt.Sprintf("--ingress-class=%s", controller.Spec.IngressClass))
+	args = append(args, "--feature-gates=EnableIPTargetType=false")
 	sort.Strings(args)
 	return args
 }

--- a/pkg/controllers/awsloadbalancercontroller/deployment_test.go
+++ b/pkg/controllers/awsloadbalancercontroller/deployment_test.go
@@ -135,6 +135,7 @@ func TestDesiredArgs(t *testing.T) {
 				"--disable-ingress-class-annotation",
 				"--disable-ingress-group-name-annotation",
 				"--webhook-cert-dir=/tls",
+				"--feature-gates=EnableIPTargetType=false",
 			)
 			expectedArgs := defaultArgs.Union(tc.expectedArgs)
 			if tc.controller.Spec.IngressClass == "" {


### PR DESCRIPTION
Description
---
In the previous release, the user was allowed to set the `target-type=ip` on `Service` and `Ingress` type resources, which is not supported on Openshift due to its dependency on AWS VPC CNI. A feature gate `EnableIPTargetType` was added to the controller to controller if `target-type=ip` is enabled. 

This PR disables IP mode for `target-type` on both `Service` and `Ingress` resources. 

Release notes: https://github.com/openshift/openshift-docs/pull/52292