### PR TITLE
OCPBUGS-3258: fix STS support for operator

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -333,6 +333,9 @@ spec:
                 volumeMounts:
                 - mountPath: /etc/aws-credentials
                   name: aws-credentials
+                - mountPath: /var/run/secrets/openshift/serviceaccount
+                  name: bound-sa-token
+                  readOnly: true
               securityContext:
                 runAsNonRoot: true
                 seccompProfile:
@@ -346,6 +349,14 @@ spec:
                   - key: credentials
                     path: credentials
                   secretName: aws-load-balancer-operator
+              - name: bound-sa-token
+                projected:
+                  defaultMode: 292
+                  sources:
+                  - serviceAccountToken:
+                      audience: openshift
+                      expirationSeconds: 3600
+                      path: token
       permissions:
       - rules:
         - apiGroups:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,6 +77,9 @@ spec:
         volumeMounts:
           - mountPath: /etc/aws-credentials
             name: aws-credentials
+          - name: bound-sa-token
+            mountPath: /var/run/secrets/openshift/serviceaccount
+            readOnly: true
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
@@ -86,3 +89,11 @@ spec:
             items:
               - key: credentials
                 path: credentials
+        - name: bound-sa-token
+          projected:
+            defaultMode: 292
+            sources:
+            - serviceAccountToken:
+                audience: openshift
+                expirationSeconds: 3600
+                path: token

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,33 +5,33 @@ post installation to ensure the operator can function correctly.
 
 ## STS Clusters
 
-In an STS Cluster, *CredentialsRequests* are not automatically provisioned by
-the `cloud-credential-operator` and requires manual intervention by the
-cluster-admin. The credentials secret needs to be provisioned using the `ccoctl` binary.
+### Post operator installation
 
-The `aws-load-balancer-operator` also relies on the `cloud-credential-operator`
-to provision the secret for *CredentialsRequest*. And so in an STS Cluster the
-secret needs to be provisioned manually. The operator will wait until the required
-secrets are created and available.
+In an STS Cluster, `CredentialsRequest`s are not automatically provisioned by
+the **cloud-credential-operator** and the manual intervention done by the
+cluster-admin is required. IAM role and policies as well as the credentials secret need to be provisioned manually for the further consumption by the pods.
+`ccoctl` binary can be used to facilitate this task.
 
-### Pre-Requisites
+Normally, the **aws-load-balancer-operator** relies on the **cloud-credential-operator**
+to provision the secret for the operated controller using `CredentialsRequest`. And so in an STS cluster this
+secret needs to be provisioned manually. The **aws-load-balancer-operator** will wait until the required
+secret is created and available before spawning the **aws-load-balancer-controller** pod.
 
-### [Extract and prepare the `ccoctl` binary](https://docs.openshift.com/container-platform/4.10/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-configuring_cco-mode-sts)
+#### Pre-Requisites
 
-### Extract required `CredentialsRequests`
+#### [Extract and prepare the `ccoctl` binary](https://docs.openshift.com/container-platform/4.11/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-configuring_cco-mode-sts)
 
-1. The **aws-load-balancer-operator** creates a *CredentialsRequest* named
-`aws-load-balancer-controller-<cr-name>` in the *openshift-cloud-credential-operator* namespace.
+#### Extract required `CredentialsRequests`
+
+1. For `AWSLoadBalancerController` CR the **aws-load-balancer-operator** creates a `CredentialsRequest` named `aws-load-balancer-controller-cluster` in the `openshift-cloud-credential-operator` namespace. Extract and save the created `CredentialsRequest` in a directory:
 
     ```bash
     oc get credentialsrequest -n openshift-cloud-credential-operator  \
-        aws-load-balancer-controller-<cr-name> -o yaml > <path-to-credrequests-dir>/cr.yaml
+        aws-load-balancer-controller-cluster -o yaml > <path-to-credrequests-dir>/cr.yaml
     ```
+    Note: currently `AWSLoadBalancerController` CR can only be named `cluster`
 
-    Extract and save the required *CredentialsRequest* in a directory.
-
-2. Use the ccoctl tool to process all *CredentialsRequest* objects in the credrequests
-directory:
+2. Use the `ccoctl` tool to process all `CredentialsRequest` objects from the credrequests directory:
 
     ```bash
     ccoctl aws create-iam-roles \
@@ -40,14 +40,23 @@ directory:
         --identity-provider-arn <oidc-arn>
     ```
 
-    For each *CredentialsRequest* object, `ccoctl` creates an IAM role with a trust
+    For each `CredentialsRequest` object, `ccoctl` creates an IAM role with a trust
     policy that is tied to the specified OIDC identity provider, and permissions
-    policy as defined in each *CredentialsRequest* object. This also generates a set
+    policy as defined in each `CredentialsRequest` object. This also generates a set
     of secrets in a **manifests** directory that is required
-    by the **aws-load-balancer-operator**.
+    by the **aws-load-balancer-controller**.
 
 3. Apply the secrets to your cluster:
 
     ```bash
     ls manifests/*-credentials.yaml | xargs -I{} oc apply -f {}
+    ```
+
+4. Verify that the corresponding **aws-load-balancer-controller** pod was created:
+
+    ```bash
+    oc -n aws-load-balancer-operator get pods
+    NAME                                                            READY   STATUS    RESTARTS   AGE
+    aws-load-balancer-controller-cluster-9b766d6-gg82c              1/1     Running   0          137m
+    aws-load-balancer-operator-controller-manager-b55ff68cc-85jzg   2/2     Running   0          3h26m
     ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -19,7 +19,7 @@ spec:
   additionalResourceTags:
     example.org/cost-center: 5113232
     example.org/security-scope: staging
-  ingressClass: cloud
+  ingressClass: alb
   config:
     replicas: 2
   enabledAddons:
@@ -124,6 +124,8 @@ spec:
     spec:
       containers:
         - image: openshift/origin-node
+          command:
+           - "/bin/socat"
           args:
             - TCP4-LISTEN:8080,reuseaddr,fork
             - EXEC:'/bin/bash -c \"printf \\\"HTTP/1.0 200 OK\r\n\r\n\\\"; sed -e \\\"/^\r/q\\\"\"'


### PR DESCRIPTION
This PR adds the missing SA token to the operator's POD to enable the usage of the prerequsite secret for the OCP cluster in STS mode. Also it documents the creation of the STS secret for the operator (not operand).

No e2e test covers STS setup, manual test: https://gist.github.com/alebedev87/f7739eb775a07350e77f0724de34728f