### PR TITLE
OCPBUGS-4052: document ALBO configuration to trust egress proxy CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ describes the design and implementation of the operator in more detail.
     2. [Running the operator](#running-the-operator)
     3. [Running the end-to-end tests](#running-the-end-to-end-tests)
     4. [Running the end-to-end tests on ROSA STS cluster](#running-the-end-to-end-tests-on-rosa-sts-cluster)
+5. [Proxy support](#proxy-support)
 
 ## Local Development
 
@@ -100,3 +101,7 @@ export ALBO_E2E_WAFV2_WEBACL_ARN=<wafv2-webacl-arn>
 export ALBO_E2E_WAF_WEBACL_ID=<wafregional-webacl-id>
 make test-e2e
 ```
+
+## Proxy support
+
+[Configuring egress proxy for AWS Load Balancer Operator](./docs/proxy.md)

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,0 +1,35 @@
+# Configuring egress proxy for AWS Load Balancer Operator
+
+If a cluster wide egress proxy is configured on the OpenShift cluster, OLM automatically updates all the operators' deployments with `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` environment variables.
+
+## Trusted Certificate Authority
+
+### Running operator
+Follow the instructions below to let AWS Load Balancer Operator trust a custom Certificate Authority (CA). The operator's OLM subscription has to have been created first.
+The operator's deployment doesn't have to be ready though.
+
+1. Create the configmap containing the CA bundle in `aws-load-balancer-operator` namespace.
+    ```bash
+    oc -n aws-load-balancer-operator create configmap trusted-ca
+    oc -n aws-load-balancer-operator label cm trusted-ca config.openshift.io/inject-trusted-cabundle=true
+    ```
+
+2. Consume the created configmap in AWS Load Balancer Operator's deployment by updating its subscription:
+
+    ```bash
+    oc -n aws-load-balancer-operator patch subscription aws-load-balancer-operator --type='merge' -p '{"spec":{"config":{"volumes":[{"name":"trusted-ca","configMap":{"name":"trusted-ca"}}],"volumeMounts":[{"name":"trusted-ca","mountPath":"/etc/pki/tls/certs/albo-tls-ca-bundle.crt","subPath":"ca-bundle.crt"}]}}}'
+    ```
+
+3. Wait for the operator deployment to finish the rollout and verify that CA bundle is added:
+
+    ```bash
+    oc -n aws-load-balancer-operator exec deploy/aws-load-balancer-operator-controller-manager -c manager -- ls -l /etc/pki/tls/certs/albo-tls-ca-bundle.crt
+
+    -rw-r--r--. 1 root 1000690000 5875 Jan 11 12:25 /etc/pki/tls/certs/albo-tls-ca-bundle.crt
+    ```
+
+4. _Optional_: make sure the operator is restarted every time the configmap contents change:
+
+    ```bash
+    oc -n aws-load-balancer-operator rollout restart deployment/aws-load-balancer-operator-controller-manager
+    ```


### PR DESCRIPTION
The operator needs a way to trust a custom CA. The cluster wide egress proxy with a "not public" certificate is one of the use cases for this. It can be achieved only by the manual intervention done by the user (cluster or namespace admin) as the operator itself makes calls to the external resources at startup (AWS endpoints to get VPC ID).

This PR adds the manual instructions which let ALBO trust a custom CA.

Manual test:
1. Replace the CA file (`/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`) with a fake CA to show that ALBO fails due to AWS golang client failure:
```
$ oc -n aws-load-balancer-operator get sub aws-load-balancer-operator -o yaml | yq .spec.config
volumeMounts:
  - mountPath: /etc/pki/ca-trust/extracted/pem
    name: trusted-ca-fake
volumes:
  - configMap:
      items:
        - key: ca-bundle.crt
          path: tls-ca-bundle.pem
      name: trusted-ca-fake
    name: trusted-ca-fake
  
$ oc -n aws-load-balancer-operator get pods
NAME                                                             READY   STATUS             RESTARTS      AGE
aws-load-balancer-operator-controller-manager-7cb6b5dd4b-qfhcd   2/2     Running            0             20m
aws-load-balancer-operator-controller-manager-7dc7ff655b-jvjmf   1/2     CrashLoopBackOff   3 (36s ago)   108s

$ oc -n aws-load-balancer-operator logs aws-load-balancer-operator-controller-manager-7dc7ff655b-jvjmf -c manager
I0112 10:37:20.254558       1 request.go:682] Waited for 1.032349291s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/metal3.io/v1alpha1?timeout=32s
1.6735198416566997e+09	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": "127.0.0.1:8080"}
1.6735198455234346e+09	ERROR	setup	failed to get VPC ID	{"error": "failed to list VPC with tag \"kubernetes.io/cluster/ci-ln-lgvt5c2-76ef8-spqtf\": operation error EC2: DescribeVpcs, exceeded maximum number of attempts, 3, https response error StatusCode: 0, RequestID: , request send failed, Post \"https://ec2.us-west-1.amazonaws.com/\": x509: certificate signed by unknown authority"}
main.main
	/remote-source/workspace/app/main.go:133
runtime.main
	/usr/lib/golang/src/runtime/proc.go:250
```

2. Keep the fake CA and add the patch of the subscription from this PR mounting therefore the real CA certificate too:
```
$ oc -n aws-load-balancer-operator get sub aws-load-balancer-operator -o yaml | yq .spec.config
volumeMounts:
  - mountPath: /etc/pki/tls/certs/albo-tls-ca-bundle.crt
    name: trusted-ca
    subPath: ca-bundle.crt
  - mountPath: /etc/pki/ca-trust/extracted/pem
    name: trusted-ca-fake
volumes:
  - configMap:
      name: trusted-ca
    name: trusted-ca
  - configMap:
      items:
        - key: ca-bundle.crt
          path: tls-ca-bundle.pem
      name: trusted-ca-fake
    name: trusted-ca-fake

$ oc -n aws-load-balancer-operator get pods
NAME                                                             READY   STATUS    RESTARTS   AGE
aws-load-balancer-operator-controller-manager-7cb6b5dd4b-4z6pl   2/2     Running   0          13s

$ oc -n aws-load-balancer-operator get pods aws-load-balancer-operator-controller-manager-7cb6b5dd4b-4z6pl -o yaml | yq .spec.volumes | grep trusted
    name: trusted-ca
  name: trusted-ca
    name: trusted-ca-fake
  name: trusted-ca-fake
```