### PR TITLE
CSV: add suggested namespace and fix manual step

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -57,8 +57,11 @@ metadata:
       ]
     capabilities: Basic Install
     olm.skipRange: <0.2.0
+    operatorframework.io/suggested-namespace: aws-load-balancer-operator
     operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    repository: https://github.com/openshift/aws-load-balancer-operator
+    support: Red Hat, Inc.
   name: aws-load-balancer-operator.v0.2.0
   namespace: placeholder
 spec:
@@ -94,7 +97,7 @@ spec:
        namespace with the following command:
 
     ```
-    cat << EOF| oc create -f -
+    cat <<EOF | oc create -f -
     apiVersion: cloudcredential.openshift.io/v1
     kind: CredentialsRequest
     metadata:
@@ -123,7 +126,7 @@ spec:
         namespace: aws-load-balancer-operator
       serviceAccountNames:
         - aws-load-balancer-operator-controller-manager
-      EOF
+    EOF
     ```
     3. Ensure the credentials have been correctly provisioned
     ```bash
@@ -463,6 +466,6 @@ spec:
   maturity: alpha
   minKubeVersion: 1.20.0
   provider:
-    name: Red Hat
+    name: Red Hat Inc.
     url: https://redhat.com
   version: 0.2.0

--- a/config/manifests/bases/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -5,6 +5,9 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     olm.skipRange: <0.2.0
+    operatorframework.io/suggested-namespace: aws-load-balancer-operator
+    repository: https://github.com/openshift/aws-load-balancer-operator
+    support: Red Hat, Inc.
   name: aws-load-balancer-operator.v0.2.0
   namespace: placeholder
 spec:
@@ -31,7 +34,7 @@ spec:
        namespace with the following command:
 
     ```
-    cat << EOF| oc create -f -
+    cat <<EOF | oc create -f -
     apiVersion: cloudcredential.openshift.io/v1
     kind: CredentialsRequest
     metadata:
@@ -60,7 +63,7 @@ spec:
         namespace: aws-load-balancer-operator
       serviceAccountNames:
         - aws-load-balancer-operator-controller-manager
-      EOF
+    EOF
     ```
     3. Ensure the credentials have been correctly provisioned
     ```bash
@@ -99,6 +102,6 @@ spec:
   maturity: alpha
   minKubeVersion: 1.20.0
   provider:
-    name: Red Hat
+    name: Red Hat Inc.
     url: https://redhat.com
   version: 0.2.0


### PR DESCRIPTION
What's inside:
- ALBO is pretty much tightly bound to its default namespace: `aws-load-balancer-operator`. This PR adds this namespace as suggested which means that it'll be shown as recommended to the end user in OperatorHub UI.
- The manual instruction to create `CredentialsRequest` had a typo - `EOF` was having to many white spaces.
- Some other informational fields which will be added to OperatorHub UI.