### PR TITLE
OCPBUGS-5295: egress proxy support for controller

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -58,6 +58,7 @@ metadata:
     capabilities: Basic Install
     olm.skipRange: <0.2.0
     operatorframework.io/suggested-namespace: aws-load-balancer-operator
+    operators.openshift.io/infrastructure-features: '["proxy-aware"]'
     operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/aws-load-balancer-operator
@@ -299,6 +300,7 @@ spec:
                 - --leader-elect
                 - --image=$(RELATED_IMAGE_CONTROLLER)
                 - --namespace=$(TARGET_NAMESPACE)
+                - --trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)
                 command:
                 - /manager
                 env:
@@ -310,6 +312,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: TRUSTED_CA_CONFIGMAP_NAME
                 image: openshift.io/aws-load-balancer-operator:latest
                 livenessProbe:
                   httpGet:
@@ -396,6 +399,14 @@ spec:
           verbs:
           - create
           - patch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - ""
           resources:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -37,6 +37,7 @@ spec:
         - "--leader-elect"
         - "--image=$(RELATED_IMAGE_CONTROLLER)"
         - "--namespace=$(TARGET_NAMESPACE)"
+        - "--trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)"
         image: controller:latest
         name: manager
         securityContext:
@@ -74,6 +75,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: TRUSTED_CA_CONFIGMAP_NAME
         volumeMounts:
           - mountPath: /etc/aws-credentials
             name: aws-credentials

--- a/config/manifests/bases/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
     capabilities: Basic Install
     olm.skipRange: <0.2.0
     operatorframework.io/suggested-namespace: aws-load-balancer-operator
+    operators.openshift.io/infrastructure-features: '["proxy-aware"]'
     repository: https://github.com/openshift/aws-load-balancer-operator
     support: Red Hat, Inc.
   name: aws-load-balancer-operator.v0.2.0

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -110,6 +110,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   - services
   verbs:

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,6 +1,8 @@
 # Configuring egress proxy for AWS Load Balancer Operator
 
-If a cluster wide egress proxy is configured on the OpenShift cluster, OLM automatically updates all the operators' deployments with `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` environment variables.
+
+If a cluster wide egress proxy is configured on the OpenShift cluster, OLM automatically updates all the operators' deployments with `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` environment variables.  
+Those variables are then propagated down to the managed controller by the AWS Load Balancer Operator.
 
 ## Trusted Certificate Authority
 
@@ -8,7 +10,7 @@ If a cluster wide egress proxy is configured on the OpenShift cluster, OLM autom
 Follow the instructions below to let AWS Load Balancer Operator trust a custom Certificate Authority (CA). The operator's OLM subscription has to have been created first.
 The operator's deployment doesn't have to be ready though.
 
-1. Create the configmap containing the CA bundle in `aws-load-balancer-operator` namespace.
+1. Create the configmap containing the CA bundle in `aws-load-balancer-operator` namespace. Run the following commands to [inject](https://docs.openshift.com/container-platform/4.12/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki) the CA bundle trusted by OpenShift into a configmap:
     ```bash
     oc -n aws-load-balancer-operator create configmap trusted-ca
     oc -n aws-load-balancer-operator label cm trusted-ca config.openshift.io/inject-trusted-cabundle=true
@@ -17,15 +19,16 @@ The operator's deployment doesn't have to be ready though.
 2. Consume the created configmap in AWS Load Balancer Operator's deployment by updating its subscription:
 
     ```bash
-    oc -n aws-load-balancer-operator patch subscription aws-load-balancer-operator --type='merge' -p '{"spec":{"config":{"volumes":[{"name":"trusted-ca","configMap":{"name":"trusted-ca"}}],"volumeMounts":[{"name":"trusted-ca","mountPath":"/etc/pki/tls/certs/albo-tls-ca-bundle.crt","subPath":"ca-bundle.crt"}]}}}'
+    oc -n aws-load-balancer-operator patch subscription aws-load-balancer-operator --type='merge' -p '{"spec":{"config":{"env":[{"name":"TRUSTED_CA_CONFIGMAP_NAME","value":"trusted-ca"}],"volumes":[{"name":"trusted-ca","configMap":{"name":"trusted-ca"}}],"volumeMounts":[{"name":"trusted-ca","mountPath":"/etc/pki/tls/certs/albo-tls-ca-bundle.crt","subPath":"ca-bundle.crt"}]}}}'
     ```
 
 3. Wait for the operator deployment to finish the rollout and verify that CA bundle is added:
 
     ```bash
-    oc -n aws-load-balancer-operator exec deploy/aws-load-balancer-operator-controller-manager -c manager -- ls -l /etc/pki/tls/certs/albo-tls-ca-bundle.crt
+    oc -n aws-load-balancer-operator exec deploy/aws-load-balancer-operator-controller-manager -c manager -- bash -c "ls -l /etc/pki/tls/certs/albo-tls-ca-bundle.crt; printenv TRUSTED_CA_CONFIGMAP_NAME"
 
     -rw-r--r--. 1 root 1000690000 5875 Jan 11 12:25 /etc/pki/tls/certs/albo-tls-ca-bundle.crt
+    trusted-ca
     ```
 
 4. _Optional_: make sure the operator is restarted every time the configmap contents change:

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/onsi/gomega v1.20.1
 	github.com/openshift/api v0.0.0-20220906163444-2df055c101a3
 	github.com/openshift/cloud-credential-operator v0.0.0-20220512195103-2ea3d8c8240a
+	github.com/operator-framework/operator-lib v0.11.0
 	github.com/spf13/cobra v1.5.0
 	k8s.io/api v0.25.3
 	k8s.io/apimachinery v0.25.3

--- a/go.sum
+++ b/go.sum
@@ -593,6 +593,8 @@ github.com/openshift/api v0.0.0-20220906163444-2df055c101a3 h1:JEFTPLulnOSzBIsZZ
 github.com/openshift/api v0.0.0-20220906163444-2df055c101a3/go.mod h1:9JWn+H7X8wEPPc9D63krigXl8r3F1Mt6/lC98brUyhQ=
 github.com/openshift/cloud-credential-operator v0.0.0-20220512195103-2ea3d8c8240a h1:YGI306ZRrlhnJ5Wwrb1dh6jgGxiZC/+Ee2g9UxY7XQE=
 github.com/openshift/cloud-credential-operator v0.0.0-20220512195103-2ea3d8c8240a/go.mod h1:qTEqKytotRAu1/N5Grbfd0DGjD56EYk4zNsHg+4Hvlw=
+github.com/operator-framework/operator-lib v0.11.0 h1:eYzqpiOfq9WBI4Trddisiq/X9BwCisZd3rIzmHRC9Z8=
+github.com/operator-framework/operator-lib v0.11.0/go.mod h1:RpyKhFAoG6DmKTDIwMuO6pI3LRc8IE9rxEYWy476o6g=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/pkg/controllers/awsloadbalancercontroller/deployment_test.go
+++ b/pkg/controllers/awsloadbalancercontroller/deployment_test.go
@@ -3,6 +3,7 @@ package awsloadbalancercontroller
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
 	"testing"
 
@@ -149,149 +150,6 @@ func TestDesiredArgs(t *testing.T) {
 				t.Fatalf("unexpected arguments\n%s", diff)
 			}
 		})
-	}
-}
-
-type testDeploymentBuilder struct {
-	name           string
-	namespace      string
-	serviceAccount string
-	replicas       *int32
-	version        string
-	containers     []corev1.Container
-	ownerReference []metav1.OwnerReference
-	volumes        []corev1.Volume
-	certsSecret    string
-}
-
-func testDeployment(name, namespace, serviceAccount string, certsSecret string) *testDeploymentBuilder {
-	return &testDeploymentBuilder{name: name, namespace: namespace, serviceAccount: serviceAccount, certsSecret: certsSecret}
-}
-
-func (b *testDeploymentBuilder) withReplicas(replicas int32) *testDeploymentBuilder {
-	b.replicas = pointer.Int32(replicas)
-	return b
-}
-
-func (b *testDeploymentBuilder) withResourceVersion(version string) *testDeploymentBuilder {
-	b.version = version
-	return b
-}
-
-func (b *testDeploymentBuilder) withContainers(containers ...corev1.Container) *testDeploymentBuilder {
-	b.containers = containers
-	return b
-}
-
-func (b *testDeploymentBuilder) withControllerReference(name string) *testDeploymentBuilder {
-	b.ownerReference = []metav1.OwnerReference{
-		{
-			APIVersion:         albo.GroupVersion.Identifier(),
-			Kind:               "AWSLoadBalancerController",
-			Name:               name,
-			Controller:         pointer.BoolPtr(true),
-			BlockOwnerDeletion: pointer.BoolPtr(true),
-		},
-	}
-	return b
-}
-
-func (b *testDeploymentBuilder) withVolumes(volumes ...corev1.Volume) *testDeploymentBuilder {
-	b.volumes = volumes
-	return b
-}
-
-func (b *testDeploymentBuilder) build() *appsv1.Deployment {
-	d := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Deployment",
-			APIVersion: "apps/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf("%s-%s", controllerResourcePrefix, b.name),
-			Namespace:       "test-namespace",
-			OwnerReferences: b.ownerReference,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					appInstanceName: b.name,
-					appLabelName:    appName,
-				},
-			},
-			Replicas: b.replicas,
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						appInstanceName: b.name,
-						appLabelName:    appName,
-					},
-				},
-				Spec: corev1.PodSpec{
-					Containers:         b.containers,
-					ServiceAccountName: b.serviceAccount,
-					Volumes:            b.volumes,
-				},
-			},
-		},
-	}
-	if b.version != "" {
-		d.ResourceVersion = b.version
-	} else {
-		d.ResourceVersion = "1"
-	}
-	return d
-}
-
-type testContainerBuilder struct {
-	name            string
-	image           string
-	args            []string
-	env             []corev1.EnvVar
-	volumeMounts    []corev1.VolumeMount
-	securityContext *corev1.SecurityContext
-}
-
-func testContainer(name, image string) *testContainerBuilder {
-	return &testContainerBuilder{
-		name:  name,
-		image: image,
-	}
-}
-
-func (b *testContainerBuilder) withEnvs(envs ...corev1.EnvVar) *testContainerBuilder {
-	b.env = envs
-	return b
-}
-
-func (b *testContainerBuilder) withArgs(args ...string) *testContainerBuilder {
-	b.args = args
-	return b
-}
-
-func (b *testContainerBuilder) withDefaultEnvs() *testContainerBuilder {
-	b.env = append(b.env, corev1.EnvVar{Name: awsRegionEnvVarName, Value: testAWSRegion}, corev1.EnvVar{Name: awsCredentialEnvVarName, Value: awsCredentialsPath}, corev1.EnvVar{Name: awsSDKLoadConfigName, Value: "1"})
-	return b
-}
-
-func (b *testContainerBuilder) withVolumeMounts(mounts ...corev1.VolumeMount) *testContainerBuilder {
-	b.volumeMounts = mounts
-	return b
-}
-
-func (b *testContainerBuilder) withSecurityContext(securityContext corev1.SecurityContext) *testContainerBuilder {
-	b.securityContext = &securityContext
-	return b
-}
-
-func (b *testContainerBuilder) build() corev1.Container {
-	return corev1.Container{
-		Name:            b.name,
-		Image:           b.image,
-		Args:            b.args,
-		Env:             b.env,
-		VolumeMounts:    b.volumeMounts,
-		SecurityContext: b.securityContext,
 	}
 }
 
@@ -564,6 +422,45 @@ func TestUpdateDeployment(t *testing.T) {
 			).build(),
 			expectUpdate: false,
 		},
+		{
+			name: "POD spec annotation added",
+			existingDeployment: testDeployment("operator", "test-namespace", "test-sa", "test-serving").withContainers(
+				testContainer("controller", "controller:v1").build(),
+			).build(),
+			desiredDeployment: testDeployment("operator", "test-namespace", "test-sa", "test-serving").withContainers(
+				testContainer("controller", "controller:v1").build(),
+			).withTemplateAnnotation("testannotation", "test").build(),
+			expectedDeployment: testDeployment("operator", "test-namespace", "test-sa", "test-serving").withContainers(
+				testContainer("controller", "controller:v1").build(),
+			).withTemplateAnnotation("testannotation", "test").build(),
+			expectUpdate: true,
+		},
+		{
+			name: "POD spec annotation changed",
+			existingDeployment: testDeployment("operator", "test-namespace", "test-sa", "test-serving").withContainers(
+				testContainer("controller", "controller:v1").build(),
+			).withTemplateAnnotation("testannotation", "old").build(),
+			desiredDeployment: testDeployment("operator", "test-namespace", "test-sa", "test-serving").withContainers(
+				testContainer("controller", "controller:v1").build(),
+			).withTemplateAnnotation("testannotation", "test").build(),
+			expectedDeployment: testDeployment("operator", "test-namespace", "test-sa", "test-serving").withContainers(
+				testContainer("controller", "controller:v1").build(),
+			).withTemplateAnnotation("testannotation", "test").build(),
+			expectUpdate: true,
+		},
+		{
+			name: "POD spec annotation didn't change",
+			existingDeployment: testDeployment("operator", "test-namespace", "test-sa", "test-serving").withContainers(
+				testContainer("controller", "controller:v1").build(),
+			).withTemplateAnnotation("testannotation", "test").build(),
+			desiredDeployment: testDeployment("operator", "test-namespace", "test-sa", "test-serving").withContainers(
+				testContainer("controller", "controller:v1").build(),
+			).withTemplateAnnotation("testannotation", "test").build(),
+			expectedDeployment: testDeployment("operator", "test-namespace", "test-sa", "test-serving").withContainers(
+				testContainer("controller", "controller:v1").build(),
+			).withTemplateAnnotation("testannotation", "test").build(),
+			expectUpdate: false,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
@@ -597,6 +494,7 @@ func TestEnsureDeployment(t *testing.T) {
 		existingObjects    []runtime.Object
 		serviceAccount     *corev1.ServiceAccount
 		controller         *albo.AWSLoadBalancerController
+		trustedCAConfigMap *corev1.ConfigMap
 		expectedDeployment *appsv1.Deployment
 		clusterName        string
 		vpcID              string
@@ -686,17 +584,277 @@ func TestEnsureDeployment(t *testing.T) {
 				}}},
 			).build(),
 		},
+		{
+			name:           "trusted CA configmap",
+			serviceAccount: &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "test-sa"}},
+			controller: &albo.AWSLoadBalancerController{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec:       albo.AWSLoadBalancerControllerSpec{},
+			},
+			existingObjects: []runtime.Object{
+				testDeployment(
+					"cluster",
+					"test-namespace",
+					"test-sa",
+					"test-serving").withContainers(
+					testContainer("controller", "controller:v0.1").build(),
+				).build(),
+			},
+			trustedCAConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-trusted-ca",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": "--ca bundle--",
+				},
+			},
+			expectedDeployment: testDeployment(
+				"cluster",
+				"test-namespace",
+				"test-sa",
+				"test-serving",
+			).withTemplateAnnotation("networking.olm.openshift.io/trusted-ca-configmap-hash", "745c799ac442a05bf2ff97c75089850a00471d9dd51392ef9ff9f6ea610d1071").
+				withContainers(
+					testContainer("controller", "test-image").withDefaultEnvs().withVolumeMounts(
+						corev1.VolumeMount{Name: "aws-credentials", MountPath: "/aws"},
+						corev1.VolumeMount{Name: "tls", MountPath: "/tls"},
+						corev1.VolumeMount{Name: "bound-sa-token", MountPath: "/var/run/secrets/openshift/serviceaccount", ReadOnly: true},
+						corev1.VolumeMount{Name: "trusted-ca", MountPath: "/etc/pki/tls/certs/albo-tls-ca-bundle.crt", SubPath: "ca-bundle.crt"},
+					).withSecurityContext(corev1.SecurityContext{
+						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						Privileged:               pointer.BoolPtr(false),
+						RunAsNonRoot:             pointer.BoolPtr(true),
+						AllowPrivilegeEscalation: pointer.BoolPtr(false),
+						SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+					}).build(),
+				).withResourceVersion("2").withVolumes(
+				corev1.Volume{Name: "aws-credentials", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-credentials"}}},
+				corev1.Volume{Name: "tls", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-serving"}}},
+				corev1.Volume{Name: "bound-sa-token", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+					DefaultMode: pointer.Int32(420),
+					Sources: []corev1.VolumeProjection{{
+						ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+							Audience:          "openshift",
+							ExpirationSeconds: pointer.Int64(3600),
+							Path:              "token",
+						},
+					}},
+				}}},
+				corev1.Volume{Name: "trusted-ca", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "test-trusted-ca"}}}},
+			).build(),
+		},
+		{
+			name:           "trusted CA configmap changed",
+			serviceAccount: &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "test-sa"}},
+			controller: &albo.AWSLoadBalancerController{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec:       albo.AWSLoadBalancerControllerSpec{},
+			},
+			existingObjects: []runtime.Object{
+				testDeployment(
+					"cluster",
+					"test-namespace",
+					"test-sa",
+					"test-serving",
+				).withTemplateAnnotation("networking.olm.openshift.io/trusted-ca-configmap-hash", "a5323ff566ec505e5b45b91b46d63360880a79056a210b8802d4b16dceaeafa2").
+					withContainers(
+						testContainer("controller", "test-image").withDefaultEnvs().withVolumeMounts(
+							corev1.VolumeMount{Name: "aws-credentials", MountPath: "/aws"},
+							corev1.VolumeMount{Name: "tls", MountPath: "/tls"},
+							corev1.VolumeMount{Name: "bound-sa-token", MountPath: "/var/run/secrets/openshift/serviceaccount", ReadOnly: true},
+							corev1.VolumeMount{Name: "trusted-ca", MountPath: "/etc/pki/tls/certs/albo-tls-ca-bundle.crt", SubPath: "ca-bundle.crt"},
+						).withSecurityContext(corev1.SecurityContext{
+							Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+							Privileged:               pointer.BoolPtr(false),
+							RunAsNonRoot:             pointer.BoolPtr(true),
+							AllowPrivilegeEscalation: pointer.BoolPtr(false),
+							SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+						}).build(),
+					).withResourceVersion("2").withVolumes(
+					corev1.Volume{Name: "aws-credentials", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-credentials"}}},
+					corev1.Volume{Name: "tls", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-serving"}}},
+					corev1.Volume{Name: "bound-sa-token", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+						DefaultMode: pointer.Int32(420),
+						Sources: []corev1.VolumeProjection{{
+							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+								Audience:          "openshift",
+								ExpirationSeconds: pointer.Int64(3600),
+								Path:              "token",
+							},
+						}},
+					}}},
+					corev1.Volume{Name: "trusted-ca", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "test-trusted-ca"}}}},
+				).build(),
+			},
+			trustedCAConfigMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-trusted-ca",
+					Namespace: "test-namespace",
+				},
+				Data: map[string]string{
+					"ca-bundle.crt": "--ca bundle--",
+				},
+			},
+			expectedDeployment: testDeployment(
+				"cluster",
+				"test-namespace",
+				"test-sa",
+				"test-serving",
+			).withTemplateAnnotation("networking.olm.openshift.io/trusted-ca-configmap-hash", "745c799ac442a05bf2ff97c75089850a00471d9dd51392ef9ff9f6ea610d1071").
+				withContainers(
+					testContainer("controller", "test-image").withDefaultEnvs().withVolumeMounts(
+						corev1.VolumeMount{Name: "aws-credentials", MountPath: "/aws"},
+						corev1.VolumeMount{Name: "tls", MountPath: "/tls"},
+						corev1.VolumeMount{Name: "bound-sa-token", MountPath: "/var/run/secrets/openshift/serviceaccount", ReadOnly: true},
+						corev1.VolumeMount{Name: "trusted-ca", MountPath: "/etc/pki/tls/certs/albo-tls-ca-bundle.crt", SubPath: "ca-bundle.crt"},
+					).withSecurityContext(corev1.SecurityContext{
+						Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+						Privileged:               pointer.BoolPtr(false),
+						RunAsNonRoot:             pointer.BoolPtr(true),
+						AllowPrivilegeEscalation: pointer.BoolPtr(false),
+						SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+					}).build(),
+				).withResourceVersion("3").withVolumes(
+				corev1.Volume{Name: "aws-credentials", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-credentials"}}},
+				corev1.Volume{Name: "tls", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-serving"}}},
+				corev1.Volume{Name: "bound-sa-token", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+					DefaultMode: pointer.Int32(420),
+					Sources: []corev1.VolumeProjection{{
+						ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+							Audience:          "openshift",
+							ExpirationSeconds: pointer.Int64(3600),
+							Path:              "token",
+						},
+					}},
+				}}},
+				corev1.Volume{Name: "trusted-ca", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: "test-trusted-ca"}}}},
+			).build(),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewClientBuilder().WithScheme(test.Scheme).WithRuntimeObjects(tc.existingObjects...).Build()
 			r := &AWSLoadBalancerControllerReconciler{
 				Client:      client,
 				Scheme:      test.Scheme,
+				Namespace:   "test-namespace",
+				Image:       "test-image",
 				ClusterName: "test-cluster",
 				VPCID:       "test-vpc",
 				AWSRegion:   testAWSRegion,
 			}
-			_, err := r.ensureDeployment(context.Background(), "test-namespace", "test-image", tc.serviceAccount, "test-credentials", "test-serving", tc.controller)
+			_, err := r.ensureDeployment(context.Background(), tc.serviceAccount, "test-credentials", "test-serving", tc.controller, tc.trustedCAConfigMap)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			tc.expectedDeployment.Spec.Template.Spec.Containers[0].Args = desiredContainerArgs(tc.controller, "test-cluster", "test-vpc")
+			var deployment appsv1.Deployment
+			err = client.Get(context.Background(), types.NamespacedName{Namespace: "test-namespace", Name: fmt.Sprintf("%s-%s", controllerResourcePrefix, tc.controller.Name)}, &deployment)
+			if err != nil {
+				t.Fatalf("failed to get deployment: %v", err)
+			}
+			if diff := cmp.Diff(&deployment, tc.expectedDeployment); diff != "" {
+				t.Fatalf("resource mismatch:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestEnsureDeploymentEnvVars(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		existingObjects    []runtime.Object
+		existingEnvVars    map[string]string
+		serviceAccount     *corev1.ServiceAccount
+		controller         *albo.AWSLoadBalancerController
+		expectedDeployment *appsv1.Deployment
+	}{
+		{
+			name:           "proxy vars specified",
+			serviceAccount: &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "test-sa"}},
+			controller: &albo.AWSLoadBalancerController{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec:       albo.AWSLoadBalancerControllerSpec{},
+			},
+			existingObjects: []runtime.Object{
+				testDeployment(
+					"cluster",
+					"test-namespace",
+					"test-sa",
+					"test-serving").withContainers(
+					testContainer("controller", "controller:v0.1").build(),
+				).build(),
+			},
+			existingEnvVars: map[string]string{
+				"HTTP_PROXY":  "http://user:XYZ@ec2-3-100-200-30.us-east-2.compute.amazonaws.com:3128",
+				"HTTPS_PROXY": "https://user:XYZ@ec2-3-100-200-30.us-east-2.compute.amazonaws.com:3128",
+				"NO_PROXY":    ".cluster.local,.svc,.us-east-2.compute.internal,10.0.0.0/16,127.0.0.1",
+			},
+			expectedDeployment: testDeployment(
+				"cluster",
+				"test-namespace",
+				"test-sa",
+				"test-serving",
+			).withContainers(
+				testContainer("controller", "test-image").
+					withDefaultEnvs().
+					withEnv("HTTP_PROXY", "http://user:XYZ@ec2-3-100-200-30.us-east-2.compute.amazonaws.com:3128").
+					withEnv("http_proxy", "http://user:XYZ@ec2-3-100-200-30.us-east-2.compute.amazonaws.com:3128").
+					withEnv("HTTPS_PROXY", "https://user:XYZ@ec2-3-100-200-30.us-east-2.compute.amazonaws.com:3128").
+					withEnv("https_proxy", "https://user:XYZ@ec2-3-100-200-30.us-east-2.compute.amazonaws.com:3128").
+					withEnv("NO_PROXY", ".cluster.local,.svc,.us-east-2.compute.internal,10.0.0.0/16,127.0.0.1").
+					withEnv("no_proxy", ".cluster.local,.svc,.us-east-2.compute.internal,10.0.0.0/16,127.0.0.1").
+					withVolumeMounts(
+						corev1.VolumeMount{Name: "aws-credentials", MountPath: "/aws"},
+						corev1.VolumeMount{Name: "tls", MountPath: "/tls"},
+						corev1.VolumeMount{Name: "bound-sa-token", MountPath: "/var/run/secrets/openshift/serviceaccount", ReadOnly: true},
+					).withSecurityContext(corev1.SecurityContext{
+					Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+					Privileged:               pointer.BoolPtr(false),
+					RunAsNonRoot:             pointer.BoolPtr(true),
+					AllowPrivilegeEscalation: pointer.BoolPtr(false),
+					SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+				}).build(),
+			).withResourceVersion("2").withVolumes(
+				corev1.Volume{Name: "aws-credentials", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-credentials"}}},
+				corev1.Volume{Name: "tls", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "test-serving"}}},
+				corev1.Volume{Name: "bound-sa-token", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+					DefaultMode: pointer.Int32(420),
+					Sources: []corev1.VolumeProjection{{
+						ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+							Audience:          "openshift",
+							ExpirationSeconds: pointer.Int64(3600),
+							Path:              "token",
+						},
+					}},
+				}}},
+			).build(),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.existingEnvVars {
+				if err := os.Setenv(k, v); err != nil {
+					t.Errorf("failed to set environment variable %q: %v", k, err)
+				}
+			}
+			defer func() {
+				for k := range tc.existingEnvVars {
+					if err := os.Unsetenv(k); err != nil {
+						t.Errorf("failed to unset environment variable %q: %v", k, err)
+					}
+				}
+			}()
+			client := fake.NewClientBuilder().WithScheme(test.Scheme).WithRuntimeObjects(tc.existingObjects...).Build()
+			r := &AWSLoadBalancerControllerReconciler{
+				Client:      client,
+				Scheme:      test.Scheme,
+				Namespace:   "test-namespace",
+				Image:       "test-image",
+				ClusterName: "test-cluster",
+				VPCID:       "test-vpc",
+				AWSRegion:   testAWSRegion,
+			}
+			_, err := r.ensureDeployment(context.Background(), tc.serviceAccount, "test-credentials", "test-serving", tc.controller, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -912,5 +1070,166 @@ func TestHasSecurityContextChanged(t *testing.T) {
 				t.Errorf("expected %v, instead was %v", tc.changed, changed)
 			}
 		})
+	}
+}
+
+type testDeploymentBuilder struct {
+	name                string
+	namespace           string
+	serviceAccount      string
+	replicas            *int32
+	version             string
+	containers          []corev1.Container
+	ownerReference      []metav1.OwnerReference
+	volumes             []corev1.Volume
+	certsSecret         string
+	templateAnnotations map[string]string
+}
+
+func testDeployment(name, namespace, serviceAccount string, certsSecret string) *testDeploymentBuilder {
+	return &testDeploymentBuilder{name: name, namespace: namespace, serviceAccount: serviceAccount, certsSecret: certsSecret}
+}
+
+func (b *testDeploymentBuilder) withReplicas(replicas int32) *testDeploymentBuilder {
+	b.replicas = pointer.Int32(replicas)
+	return b
+}
+
+func (b *testDeploymentBuilder) withResourceVersion(version string) *testDeploymentBuilder {
+	b.version = version
+	return b
+}
+
+func (b *testDeploymentBuilder) withContainers(containers ...corev1.Container) *testDeploymentBuilder {
+	b.containers = containers
+	return b
+}
+
+func (b *testDeploymentBuilder) withControllerReference(name string) *testDeploymentBuilder {
+	b.ownerReference = []metav1.OwnerReference{
+		{
+			APIVersion:         albo.GroupVersion.Identifier(),
+			Kind:               "AWSLoadBalancerController",
+			Name:               name,
+			Controller:         pointer.BoolPtr(true),
+			BlockOwnerDeletion: pointer.BoolPtr(true),
+		},
+	}
+	return b
+}
+
+func (b *testDeploymentBuilder) withVolumes(volumes ...corev1.Volume) *testDeploymentBuilder {
+	b.volumes = volumes
+	return b
+}
+
+func (b *testDeploymentBuilder) withTemplateAnnotation(k, v string) *testDeploymentBuilder {
+	if b.templateAnnotations == nil {
+		b.templateAnnotations = map[string]string{}
+	}
+	b.templateAnnotations[k] = v
+	return b
+}
+
+func (b *testDeploymentBuilder) build() *appsv1.Deployment {
+	d := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            fmt.Sprintf("%s-%s", controllerResourcePrefix, b.name),
+			Namespace:       "test-namespace",
+			OwnerReferences: b.ownerReference,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					appInstanceName: b.name,
+					appLabelName:    appName,
+				},
+			},
+			Replicas: b.replicas,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						appInstanceName: b.name,
+						appLabelName:    appName,
+					},
+					Annotations: b.templateAnnotations,
+				},
+				Spec: corev1.PodSpec{
+					Containers:         b.containers,
+					ServiceAccountName: b.serviceAccount,
+					Volumes:            b.volumes,
+				},
+			},
+		},
+	}
+	if b.version != "" {
+		d.ResourceVersion = b.version
+	} else {
+		d.ResourceVersion = "1"
+	}
+	return d
+}
+
+type testContainerBuilder struct {
+	name            string
+	image           string
+	args            []string
+	env             []corev1.EnvVar
+	volumeMounts    []corev1.VolumeMount
+	securityContext *corev1.SecurityContext
+}
+
+func testContainer(name, image string) *testContainerBuilder {
+	return &testContainerBuilder{
+		name:  name,
+		image: image,
+	}
+}
+
+func (b *testContainerBuilder) withEnvs(envs ...corev1.EnvVar) *testContainerBuilder {
+	b.env = envs
+	return b
+}
+
+func (b *testContainerBuilder) withArgs(args ...string) *testContainerBuilder {
+	b.args = args
+	return b
+}
+
+func (b *testContainerBuilder) withDefaultEnvs() *testContainerBuilder {
+	b.env = append(b.env, []corev1.EnvVar{
+		{Name: awsRegionEnvVarName, Value: testAWSRegion},
+		{Name: awsCredentialEnvVarName, Value: awsCredentialsPath},
+		{Name: awsSDKLoadConfigName, Value: "1"}}...)
+	return b
+}
+
+func (b *testContainerBuilder) withEnv(name, value string) *testContainerBuilder {
+	b.env = append(b.env, corev1.EnvVar{Name: name, Value: value})
+	return b
+}
+
+func (b *testContainerBuilder) withVolumeMounts(mounts ...corev1.VolumeMount) *testContainerBuilder {
+	b.volumeMounts = mounts
+	return b
+}
+
+func (b *testContainerBuilder) withSecurityContext(securityContext corev1.SecurityContext) *testContainerBuilder {
+	b.securityContext = &securityContext
+	return b
+}
+
+func (b *testContainerBuilder) build() corev1.Container {
+	return corev1.Container{
+		Name:            b.name,
+		Image:           b.image,
+		Args:            b.args,
+		Env:             b.env,
+		VolumeMounts:    b.volumeMounts,
+		SecurityContext: b.securityContext,
 	}
 }

--- a/pkg/controllers/test/crd/credentialsrequest.yaml
+++ b/pkg/controllers/test/crd/credentialsrequest.yaml
@@ -1,0 +1,170 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  name: credentialsrequests.cloudcredential.openshift.io
+spec:
+  group: cloudcredential.openshift.io
+  names:
+    kind: CredentialsRequest
+    listKind: CredentialsRequestList
+    plural: credentialsrequests
+    singular: credentialsrequest
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: CredentialsRequest is the Schema for the credentialsrequests
+          API
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CredentialsRequestSpec defines the desired state of CredentialsRequest
+            type: object
+            required:
+            - secretRef
+            properties:
+              providerSpec:
+                description: ProviderSpec contains the cloud provider specific credentials
+                  specification.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              secretRef:
+                description: SecretRef points to the secret where the credentials
+                  should be stored once generated.
+                type: object
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+              serviceAccountNames:
+                description: ServiceAccountNames contains a list of ServiceAccounts
+                  that will use permissions associated with this CredentialsRequest.
+                  This is not used by CCO, but the information is needed for being
+                  able to properly set up access control in the cloud provider when
+                  the ServiceAccounts are used as part of the cloud credentials flow.
+                type: array
+                items:
+                  type: string
+          status:
+            description: CredentialsRequestStatus defines the observed state of CredentialsRequest
+            type: object
+            required:
+            - lastSyncGeneration
+            - provisioned
+            properties:
+              conditions:
+                description: Conditions includes detailed status for the CredentialsRequest
+                type: array
+                items:
+                  description: CredentialsRequestCondition contains details for any
+                    of the conditions on a CredentialsRequest object
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastProbeTime:
+                      description: LastProbeTime is the last time we probed the condition
+                      type: string
+                      format: date-time
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human-readable message indicating
+                        details about the last transition
+                      type: string
+                    reason:
+                      description: Reason is a unique, one-word, CamelCase reason
+                        for the condition's last transition
+                      type: string
+                    status:
+                      description: Status is the status of the condition
+                      type: string
+                    type:
+                      description: Type is the specific type of the condition
+                      type: string
+              lastSyncCloudCredsSecretResourceVersion:
+                description: LastSyncCloudCredsSecretResourceVersion is the resource
+                  version of the cloud credentials secret resource when the credentials
+                  request resource was last synced. Used to determine if the the cloud
+                  credentials have been updated since the last sync.
+                type: string
+              lastSyncGeneration:
+                description: LastSyncGeneration is the generation of the credentials
+                  request resource that was last synced. Used to determine if the
+                  object has changed and requires a sync.
+                type: integer
+                format: int64
+              lastSyncTimestamp:
+                description: LastSyncTimestamp is the time that the credentials were
+                  last synced.
+                type: string
+                format: date-time
+              providerStatus:
+                description: ProviderStatus contains cloud provider specific status.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              provisioned:
+                description: Provisioned is true once the credentials have been initially
+                  provisioned.
+                type: boolean
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/controllers/watch_test.go
+++ b/pkg/controllers/watch_test.go
@@ -1,0 +1,119 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	albov1alpha1 "github.com/openshift/aws-load-balancer-operator/api/v1alpha1"
+)
+
+var _ = Describe("AWS Load Balancer Reconciler Watch Predicates", func() {
+	Context("AWS Load Balancer Controller", func() {
+		It("does not match the unique name", func() {
+			albc := &albov1alpha1.AWSLoadBalancerController{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "wrongname",
+				},
+			}
+			var gotReq ctrl.Request
+			errCh := waitForRequest(reconcileCollector.Requests, 1*time.Second, &gotReq)
+			Expect(k8sClient.Create(context.Background(), albc)).Should(Succeed())
+			Expect(<-errCh).NotTo(BeNil())
+		})
+		It("matches the unique name", func() {
+			albc := &albov1alpha1.AWSLoadBalancerController{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+			}
+			expectedReq := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: "cluster",
+				},
+			}
+			var gotReq ctrl.Request
+			errCh := waitForRequest(reconcileCollector.Requests, 2*time.Second, &gotReq)
+			Expect(k8sClient.Create(context.Background(), albc)).Should(Succeed())
+			Expect(<-errCh).To(BeNil())
+			Expect(gotReq).To(Equal(expectedReq))
+		})
+	})
+
+	Context("Trusted CA configmap", func() {
+		It("does not match the namespace passed to reconcile", func() {
+			wrongNs := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "wrongns",
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), wrongNs)).Should(Succeed())
+			trustedCAConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-trusted-ca",
+					Namespace: "wrongns",
+				},
+			}
+			var gotReq ctrl.Request
+			errCh := waitForRequest(reconcileCollector.Requests, 1*time.Second, &gotReq)
+			Expect(k8sClient.Create(context.Background(), trustedCAConfigMap)).Should(Succeed())
+			Expect(<-errCh).NotTo(BeNil())
+		})
+		It("does not match the name passed to reconcile", func() {
+			trustedCAConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "wrongname",
+					Namespace: "aws-load-balancer-operator",
+				},
+			}
+			var gotReq ctrl.Request
+			errCh := waitForRequest(reconcileCollector.Requests, 1*time.Second, &gotReq)
+			Expect(k8sClient.Create(context.Background(), trustedCAConfigMap)).Should(Succeed())
+			Expect(<-errCh).NotTo(BeNil())
+		})
+		It("matches the name passed to reconcile", func() {
+			trustedCAConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-trusted-ca",
+					Namespace: "aws-load-balancer-operator",
+				},
+			}
+			expectedReq := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: "cluster",
+				},
+			}
+			var gotReq ctrl.Request
+			errCh := waitForRequest(reconcileCollector.Requests, 1*time.Second, &gotReq)
+			Expect(k8sClient.Create(context.Background(), trustedCAConfigMap)).Should(Succeed())
+			Expect(<-errCh).To(BeNil())
+			Expect(gotReq).To(Equal(expectedReq))
+		})
+	})
+})
+
+func waitForRequest(requests chan ctrl.Request, timeout time.Duration, res *ctrl.Request) <-chan error {
+	errCh := make(chan error)
+	go func() {
+		for {
+			select {
+			case req := <-requests:
+				*res = req
+				errCh <- nil
+				return
+			case <-time.After(timeout):
+				errCh <- fmt.Errorf("timed out waiting for request")
+				return
+			}
+		}
+	}()
+	return errCh
+}

--- a/vendor/github.com/operator-framework/operator-lib/LICENSE
+++ b/vendor/github.com/operator-framework/operator-lib/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/operator-framework/operator-lib/proxy/doc.go
+++ b/vendor/github.com/operator-framework/operator-lib/proxy/doc.go
@@ -1,0 +1,33 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package proxy implements helper functions to facilitate making operators proxy-aware.
+
+This package assumes that proxy environment variables `HTTPS_PROXY`,
+`HTTP_PROXY`, and/or `NO_PROXY` are set in the Operator environment, typically
+via the Operator deployment.
+
+Proxy-aware operators can use the ReadProxyVarsFromEnv to retrieve these values
+as a slice of corev1 EnvVars. Each of the proxy variables are duplicated in
+upper and lower case to support applications that use either. In their
+reconcile functions, Operator authors are then responsible for setting these
+variables in the Container Envs that must use the proxy, For example:
+
+	// Pods with Kubernetes < 1.22
+	for i, cSpec := range (myPod.Spec.Containers) {
+		myPod.Spec.Containers[i].Env = append(cSpec.Env, ReadProxyVarsFromEnv()...)
+	}
+*/
+package proxy

--- a/vendor/github.com/operator-framework/operator-lib/proxy/proxy.go
+++ b/vendor/github.com/operator-framework/operator-lib/proxy/proxy.go
@@ -1,0 +1,45 @@
+// Copyright 2021 The Operator-SDK Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"os"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ProxyEnvNames are standard environment variables for proxies
+var ProxyEnvNames = []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
+
+// ReadProxyVarsFromEnv retrieves the standard proxy-related environment
+// variables from the running environment and returns a slice of corev1 EnvVar
+// containing upper and lower case versions of those variables.
+func ReadProxyVarsFromEnv() []corev1.EnvVar {
+	envVars := []corev1.EnvVar{}
+	for _, s := range ProxyEnvNames {
+		value, isSet := os.LookupEnv(s)
+		if isSet {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  s,
+				Value: value,
+			}, corev1.EnvVar{
+				Name:  strings.ToLower(s),
+				Value: value,
+			})
+		}
+	}
+	return envVars
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -672,6 +672,9 @@ github.com/openshift/api/config/v1
 # github.com/openshift/cloud-credential-operator v0.0.0-20220512195103-2ea3d8c8240a
 ## explicit; go 1.18
 github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1
+# github.com/operator-framework/operator-lib v0.11.0
+## explicit; go 1.17
+github.com/operator-framework/operator-lib/proxy
 # github.com/pelletier/go-toml v1.9.5
 ## explicit; go 1.12
 github.com/pelletier/go-toml


### PR DESCRIPTION
- Propagate the proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) down to the controller.
- Add the custom trusted CA bundle to the controller: new volume and volume mount in the desired controller's deployment.
- Redeploy the controller if the custom CA bundle configmap changes: new watch for the CA bundle configmap in the operator, new annotation in the desired controller's deployment.