### PR TITLE
OCPBUGS-14846: update the controller image to use TLS1.2 as minumum version for webhook server

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -323,7 +323,7 @@ spec:
                 - name: AWS_SHARED_CREDENTIALS_FILE
                   value: /etc/aws-credentials/credentials
                 - name: RELATED_IMAGE_CONTROLLER
-                  value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:95d71cc4e7e594fd7cca52c5904c3cf86837bf1e90955eecee6b5cd0862eb501
+                  value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:f359f63169432cf8029b189f6605f21d660f0f805b91d55fe964185d0b8ae0b2
                 - name: TARGET_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,7 +70,7 @@ spec:
           - name: AWS_SHARED_CREDENTIALS_FILE
             value: /etc/aws-credentials/credentials
           - name: RELATED_IMAGE_CONTROLLER
-            value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:95d71cc4e7e594fd7cca52c5904c3cf86837bf1e90955eecee6b5cd0862eb501
+            value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:f359f63169432cf8029b189f6605f21d660f0f805b91d55fe964185d0b8ae0b2
           - name: TARGET_NAMESPACE
             valueFrom:
               fieldRef:


### PR DESCRIPTION
This PR adds the aws-load-balancer-controller image containing the fix for the FIPS clusters whose maximum TLS version cannot be greater than 1.2.

The manual test can be found in the description of [the controller PR](https://github.com/openshift/aws-load-balancer-controller/pull/12).