### PR TITLE
OWNERS: add NetworkEdge team

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,18 @@
 approvers:
   - Miciah
   - alebedev87
-  - arjunrn
   - thejasn
+  - gcs278
+  - candita
+  - frobware
+  - rfredette
+  - miheer
 reviewers:
   - Miciah
   - alebedev87
-  - arjunrn
   - thejasn
+  - gcs278
+  - candita
+  - frobware
+  - rfredette
+  - miheer


### PR DESCRIPTION
Adding the whole NetworkEdge team as reviewers and approvers.