### PR TITLE
OCPBUGS-22893: e2e- action items post 1.1 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,9 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-E2E_TIMEOUT ?= 1h
+# The E2E has 11 tests which interact with AWS (LB provisioning), each one taking approximately 5 minutes.
+# The previous timeout (1 hour) was too close to the time required for a run.
+E2E_TIMEOUT ?= 90m
 
 # Use docker as the default container engine
 CONTAINER_ENGINE ?= docker

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -583,6 +583,58 @@ func TestAWSLoadBalancerControllerWithInternalLoadBalancer(t *testing.T) {
 }
 
 func TestAWSLoadBalancerControllerWithWAFv2(t *testing.T) {
+	// Creating the Web ACL as early as possible as it's not available immediately
+	// for the association with a load balancer.
+	t.Logf("Getting WAFv2 WebACL")
+	var aclARN string
+	if !stsModeRequested() {
+		wafClient := wafv2.NewFromConfig(cfg)
+		webACLName := "echoserver-acl"
+		acl, err := findAWSWebACL(wafClient, webACLName)
+		if err != nil {
+			t.Logf("failed to find %q aws wafv2 acl due to %v, continue to creation anyway", webACLName, err)
+		}
+		if acl == nil {
+			t.Logf("WAFv2 ACL %q was not found, creating one", webACLName)
+			createdACL, err := wafClient.CreateWebACL(context.Background(), &wafv2.CreateWebACLInput{
+				DefaultAction: &wafv2types.DefaultAction{Block: &wafv2types.BlockAction{}},
+				Name:          aws.String(webACLName),
+				Scope:         wafv2types.ScopeRegional,
+				VisibilityConfig: &wafv2types.VisibilityConfig{
+					CloudWatchMetricsEnabled: false,
+					MetricName:               aws.String("echoserver"),
+					SampledRequestsEnabled:   false,
+				},
+			})
+			if err != nil {
+				t.Fatalf("failed to create aws wafv2 acl due to %v", err)
+			}
+			acl = createdACL.Summary
+		}
+
+		aclARN = *acl.ARN
+		t.Logf("Found WAFv2 WebACL. ID: %s, Name: %s, ARN: %s", *acl.Id, *acl.Name, aclARN)
+
+		defer func() {
+			_, err = wafClient.DeleteWebACL(context.TODO(), &wafv2.DeleteWebACLInput{
+				Id:        aws.String(*acl.Id),
+				Name:      aws.String(webACLName),
+				LockToken: acl.LockToken,
+				Scope:     wafv2types.ScopeRegional,
+			})
+			if err != nil {
+				t.Fatalf("failed to delete aws wafv2 acl due to %v", err)
+			}
+		}()
+	} else {
+		// Web ACLs are provisioned by CI on ROSA cluster.
+		aclARN = os.Getenv(wafv2WebACLARNVarName)
+		if aclARN == "" {
+			t.Fatalf("no wafv2 webacl arn provided")
+		}
+	}
+	t.Logf("Got WAFv2 WebACL. ARN: %s", aclARN)
+
 	testWorkloadNamespace := "aws-load-balancer-test-wafv2"
 	t.Logf("Creating test namespace %q", testWorkloadNamespace)
 	echoNs := createTestNamespace(t, testWorkloadNamespace)
@@ -613,56 +665,6 @@ func TestAWSLoadBalancerControllerWithWAFv2(t *testing.T) {
 	defer func() {
 		waitForDeletion(context.TODO(), t, kubeClient, echoSvc, defaultTimeout)
 	}()
-
-	var aclARN string
-	if !stsModeRequested() {
-		wafClient := wafv2.NewFromConfig(cfg)
-		webACLName := "echoserver-acl"
-		acl, err := findAWSWebACL(wafClient, webACLName)
-		if err != nil {
-			t.Logf("failed to find %q aws wafv2 acl due to %v, continue to creation anyway", webACLName, err)
-		}
-		if acl == nil {
-			t.Logf("AWS WAFv2 ACL %q was not found, creating one", webACLName)
-			createdACL, err := wafClient.CreateWebACL(context.Background(), &wafv2.CreateWebACLInput{
-				DefaultAction: &wafv2types.DefaultAction{Block: &wafv2types.BlockAction{}},
-				Name:          aws.String(webACLName),
-				Scope:         wafv2types.ScopeRegional,
-				VisibilityConfig: &wafv2types.VisibilityConfig{
-					CloudWatchMetricsEnabled: false,
-					MetricName:               aws.String("echoserver"),
-					SampledRequestsEnabled:   false,
-				},
-			})
-			if err != nil {
-				t.Fatalf("failed to create aws wafv2 acl due to %v", err)
-			}
-			acl = createdACL.Summary
-		}
-
-		aclARN = *acl.ARN
-		t.Logf("Found AWS WAFv2 WebACL. ID: %s, Name: %s, ARN: %s", *acl.Id, *acl.Name, aclARN)
-
-		defer func() {
-			_, err = wafClient.DeleteWebACL(context.TODO(), &wafv2.DeleteWebACLInput{
-				Id:        aws.String(*acl.Id),
-				Name:      aws.String(webACLName),
-				LockToken: acl.LockToken,
-				Scope:     wafv2types.ScopeRegional,
-			})
-			if err != nil {
-				t.Fatalf("failed to delete aws wafv2 acl due to %v", err)
-			}
-		}()
-	} else {
-		// Web ACLs are provisioned by CI on ROSA cluster.
-		aclARN = os.Getenv(wafv2WebACLARNVarName)
-		if aclARN == "" {
-			t.Fatalf("no wafv2 webacl arn provided")
-		}
-	}
-
-	t.Logf("Got AWS WAFv2 WebACL. ARN: %s", aclARN)
 
 	t.Log("Creating Ingress Resource with default ingress class")
 	ingName := types.NamespacedName{Name: "echoserver", Namespace: testWorkloadNamespace}
@@ -711,36 +713,7 @@ func TestAWSLoadBalancerControllerWithWAFv2(t *testing.T) {
 }
 
 func TestAWSLoadBalancerControllerWithWAFRegional(t *testing.T) {
-	testWorkloadNamespace := "aws-load-balancer-test-wafregional"
-	t.Logf("Creating test namespace %q", testWorkloadNamespace)
-	echoNs := createTestNamespace(t, testWorkloadNamespace)
-	defer func() {
-		waitForDeletion(context.TODO(), t, kubeClient, echoNs, defaultTimeout)
-	}()
-
-	t.Log("Creating aws load balancer controller instance with default ingress class")
-
-	alb := newALBCBuilder().withAddons(albo.AWSAddonWAFv1).withRoleARNIf(stsModeRequested(), controllerRoleARN).build()
-	if err := kubeClient.Create(context.TODO(), alb); err != nil {
-		t.Fatalf("failed to create aws load balancer controller: %v", err)
-	}
-	defer func() {
-		waitForDeletion(context.TODO(), t, kubeClient, alb, defaultTimeout)
-	}()
-
-	expected := []appsv1.DeploymentCondition{
-		{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
-	}
-	deploymentName := types.NamespacedName{Name: "aws-load-balancer-controller-cluster", Namespace: "aws-load-balancer-operator"}
-	if err := waitForDeploymentStatusCondition(context.TODO(), t, kubeClient, defaultTimeout, deploymentName, expected...); err != nil {
-		t.Fatalf("did not get expected available condition for deployment: %v", err)
-	}
-
-	echoSvc := createTestWorkload(t, testWorkloadNamespace)
-	defer func() {
-		waitForDeletion(context.TODO(), t, kubeClient, echoSvc, defaultTimeout)
-	}()
-
+	t.Log("Getting WAFRegional WebACL")
 	var webACLID string
 	if !stsModeRequested() {
 		wafClient := waf.NewFromConfig(cfg)
@@ -780,8 +753,37 @@ func TestAWSLoadBalancerControllerWithWAFRegional(t *testing.T) {
 			t.Fatalf("no wafregional webacl id provided")
 		}
 	}
+	t.Logf("Got WAFRegional WebACL. ID: %s", webACLID)
 
-	t.Logf("Got AWS WAFRegional WebACL. ID: %s", webACLID)
+	testWorkloadNamespace := "aws-load-balancer-test-wafregional"
+	t.Logf("Creating test namespace %q", testWorkloadNamespace)
+	echoNs := createTestNamespace(t, testWorkloadNamespace)
+	defer func() {
+		waitForDeletion(context.TODO(), t, kubeClient, echoNs, defaultTimeout)
+	}()
+
+	t.Log("Creating aws load balancer controller instance with default ingress class")
+
+	alb := newALBCBuilder().withAddons(albo.AWSAddonWAFv1).withRoleARNIf(stsModeRequested(), controllerRoleARN).build()
+	if err := kubeClient.Create(context.TODO(), alb); err != nil {
+		t.Fatalf("failed to create aws load balancer controller: %v", err)
+	}
+	defer func() {
+		waitForDeletion(context.TODO(), t, kubeClient, alb, defaultTimeout)
+	}()
+
+	expected := []appsv1.DeploymentCondition{
+		{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+	}
+	deploymentName := types.NamespacedName{Name: "aws-load-balancer-controller-cluster", Namespace: "aws-load-balancer-operator"}
+	if err := waitForDeploymentStatusCondition(context.TODO(), t, kubeClient, defaultTimeout, deploymentName, expected...); err != nil {
+		t.Fatalf("did not get expected available condition for deployment: %v", err)
+	}
+
+	echoSvc := createTestWorkload(t, testWorkloadNamespace)
+	defer func() {
+		waitForDeletion(context.TODO(), t, kubeClient, echoSvc, defaultTimeout)
+	}()
 
 	t.Log("Creating Ingress Resource with default ingress class")
 	ingName := types.NamespacedName{Name: "echoserver", Namespace: testWorkloadNamespace}
@@ -829,7 +831,7 @@ func TestAWSLoadBalancerControllerWithWAFRegional(t *testing.T) {
 	}
 }
 
-func TestIngressGroup(t *testing.T) {
+func TestAWSLoadBalancerControllerWithIngressGroup(t *testing.T) {
 	testWorkloadNamespace := "aws-load-balancer-test-ing-group"
 	t.Logf("Creating test namespace %q", testWorkloadNamespace)
 	echoNs := createTestNamespace(t, testWorkloadNamespace)

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -138,12 +138,6 @@ func TestMain(m *testing.M) {
 	} else {
 		fmt.Println("Controller role is expected to exist when the test is run on a ROSA STS cluster")
 		controllerRoleARN = mustGetEnv(controllerRoleARNVarName)
-		// TODO: remove the copying once ROSA can provision 4.14 clusters
-		// which support stsIAMRoleARN field in CredentialsRequest.
-		if err := copySecret(context.TODO(), kubeClient, controllerSecretName, "aws-load-balancer-controller-credentialsrequest-cluster"); err != nil {
-			fmt.Printf("failed to copy controller secret: %v", err)
-			os.Exit(1)
-		}
 	}
 
 	os.Exit(m.Run())

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -508,24 +508,3 @@ func mustGetEnv(name string) string {
 	}
 	return val
 }
-
-// copySecret makes a copy of a secret in the operator's namespace.
-func copySecret(ctx context.Context, kubeClient client.Client, nameIn, nameOut string) error {
-	secretIn := &corev1.Secret{}
-	if err := kubeClient.Get(ctx, types.NamespacedName{Name: nameIn, Namespace: operatorNamespace}, secretIn); err != nil {
-		return err
-	}
-
-	secretOut := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      nameOut,
-			Namespace: operatorNamespace,
-		},
-		Data: secretIn.Data,
-	}
-	if err := kubeClient.Create(ctx, secretOut); err != nil {
-		return err
-	}
-
-	return nil
-}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -90,6 +90,7 @@ func getIngress(ctx context.Context, t *testing.T, cl client.Client, timeout tim
 			return false, nil
 		}
 		if len(ing.Status.LoadBalancer.Ingress) <= 0 || len(ing.Status.LoadBalancer.Ingress[0].Hostname) <= 0 {
+			t.Logf("no load balancer found for ingress %s (retrying)", ingressName.Name)
 			return false, nil
 		}
 		address = ing.Status.LoadBalancer.Ingress[0].Hostname


### PR DESCRIPTION
Action items:
- Follow up of [a TODO in the e2e](https://github.com/openshift/aws-load-balancer-operator/blob/main/test/e2e/operator_test.go#L141-L142):
    - Remove the copying of the credentials secret provisioned by the CI, ROSA can spawn 4.14 clusters now, so `STSIAMRoleARN` field is now available
- Follow-up of [a problem](https://github.com/openshift/aws-load-balancer-operator/pull/115#issuecomment-1783563662) found in the last PRs before the release:
   - Create AWS Web ACLs as earlier as possible to save some time waiting for its availability. This helped to drop the test executing from ~800 seconds to ~500 seconds.
   - Default e2e timeout is increased to `90m` as the time need for successful run is too close to the previous `60m` timeout.