### PR TITLE
OCPBUGS-27023: add infrastructure annotations

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -66,9 +66,15 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "true"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: <1.1.0
     operatorframework.io/suggested-namespace: aws-load-balancer-operator
-    operators.openshift.io/infrastructure-features: '["proxy-aware"]'
     operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/aws-load-balancer-operator

--- a/config/manifests/bases/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -4,9 +4,15 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "true"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     olm.skipRange: <1.1.0
     operatorframework.io/suggested-namespace: aws-load-balancer-operator
-    operators.openshift.io/infrastructure-features: '["proxy-aware"]'
     repository: https://github.com/openshift/aws-load-balancer-operator
     support: Red Hat, Inc.
   name: aws-load-balancer-operator.v1.1.0


### PR DESCRIPTION
According to the Red Hat Operator's [Best practices](https://docs.engineering.redhat.com/display/CFC/Best_Practices) the infrastructure annotations are now required. The [old "infrastructure-features" annotation is deprecated](https://github.com/openshift/openshift-docs/pull/69579) hence I removed it.