### PR TITLE
Use OpenShift generated trust bundle by default

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator-trusted-cabundle-config_v1_configmap.yaml
+++ b/bundle/manifests/aws-load-balancer-operator-trusted-cabundle-config_v1_configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: aws-load-balancer-operator-trusted-cabundle

--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -286,6 +286,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: TRUSTED_CA_CONFIGMAP_NAME
+                  value: aws-load-balancer-operator-trusted-cabundle
                 image: openshift.io/aws-load-balancer-operator:latest
                 livenessProbe:
                   httpGet:
@@ -327,6 +328,9 @@ spec:
                 - mountPath: /var/run/secrets/openshift/serviceaccount
                   name: bound-sa-token
                   readOnly: true
+                - mountPath: /etc/pki/tls/certs/albo-tls-ca-bundle.crt
+                  name: trusted-cabundle
+                  subPath: ca-bundle.crt
               securityContext:
                 runAsNonRoot: true
                 seccompProfile:
@@ -342,6 +346,10 @@ spec:
                       audience: openshift
                       expirationSeconds: 3600
                       path: token
+              - name: trusted-cabundle
+                configMap:
+                  defaultMode: 420
+                  name: aws-load-balancer-operator-trusted-cabundle
       permissions:
       - rules:
         - apiGroups:


### PR DESCRIPTION
Currently it is required to [manually reconfigure](https://github.com/openshift/aws-load-balancer-operator/blob/b757416f27d3a84113b4660358b98cca0064731f/docs/proxy.md) the operator installation in order to have it use the OpenShift generated trusted cabundle.

Since this operator is solely for OpenShift [1], there is zero reason to have this be a manual, non-default action.

[1] 
![image](https://github.com/openshift/aws-load-balancer-operator/assets/223366/3d32a162-648f-4682-8d4c-346da8ad988e)
