### PR TITLE
Add support for all partitions

### DIFF
--- a/assets/operator-iam-policy.json
+++ b/assets/operator-iam-policy.json
@@ -14,7 +14,7 @@
         "ec2:DeleteTags"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:ec2:*:*:subnet/*"
+      "Resource": "arn:*:ec2:*:*:subnet/*"
     },
     {
       "Action": [

--- a/hack/operator-credentials-request.yaml
+++ b/hack/operator-credentials-request.yaml
@@ -16,7 +16,7 @@ spec:
           - ec2:CreateTags
           - ec2:DeleteTags
         effect: Allow
-        resource: arn:aws:ec2:*:*:subnet/*
+        resource: arn:*:ec2:*:*:subnet/*
       - action:
           - ec2:DescribeVpcs
         effect: Allow

--- a/hack/operator-permission-policy.json
+++ b/hack/operator-permission-policy.json
@@ -14,7 +14,7 @@
         "ec2:DeleteTags"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:ec2:*:*:subnet/*"
+      "Resource": "arn:*:ec2:*:*:subnet/*"
     },
     {
       "Action": [

--- a/pkg/operator/iam_policy.go
+++ b/pkg/operator/iam_policy.go
@@ -20,7 +20,7 @@ func GetIAMPolicy() IAMPolicy {
 			},
 			{
 				Effect:          "Allow",
-				Resource:        "arn:aws:ec2:*:*:subnet/*",
+				Resource:        "arn:*:ec2:*:*:subnet/*",
 				PolicyCondition: cco.IAMPolicyCondition{},
 				Action: []string{
 					"ec2:CreateTags",

--- a/pkg/utils/resource/update/credentials_request_test.go
+++ b/pkg/utils/resource/update/credentials_request_test.go
@@ -122,7 +122,7 @@ func Test_CredentialsRequest(t *testing.T) {
 				StatementEntries: []cco.StatementEntry{
 					{
 						Effect:          "Allow",
-						Resource:        "arn:aws:ec2:*:*:subnet/*",
+						Resource:        "arn:*:ec2:*:*:subnet/*",
 						PolicyCondition: cco.IAMPolicyCondition{},
 						Action: []string{
 							"ec2:DescribeSubnets",


### PR DESCRIPTION
This operator is currently not working in `aws-gov`, `aws-iso` and `aws-iso-b` partitions because the ARN condition is hardcoded to the `aws` partition.

This PR allows the operator to run in all AWS partitions.