### PR TITLE
OCPBUGS-28230: Add FallbackToLogsOnError to all pod containers

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -268,6 +268,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                terminationMessagePolicy: FallbackToLogsOnError
               - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
@@ -323,6 +324,7 @@ spec:
                     port: 8081
                   initialDelaySeconds: 15
                   periodSeconds: 20
+                terminationMessagePolicy: FallbackToLogsOnError
                 volumeMounts:
                 - mountPath: /var/run/secrets/openshift/serviceaccount
                   name: bound-sa-token

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -33,3 +33,4 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
+        terminationMessagePolicy: FallbackToLogsOnError

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -10,6 +10,7 @@ spec:
       - name: manager
         args:
         - "--config=controller_manager_config.yaml"
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: manager-config
           mountPath: /controller_manager_config.yaml

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -13,6 +13,7 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -85,6 +85,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: TRUSTED_CA_CONFIGMAP_NAME
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
           - name: bound-sa-token
             mountPath: /var/run/secrets/openshift/serviceaccount


### PR DESCRIPTION
* `bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml`:
* `config/default/manager_auth_proxy_patch.yaml`:
* `config/default/manager_config_patch.yaml`:
* `config/default/manager_webhook_patch.yaml`:
* `config/manager/manager.yaml`: Specify `terminationMessagePolicy: FallbackToLogsOnError` on every pod container for easier debugging.