### PR TITLE
OCPBUGS-24653: Ensure FIPS compliance for operator image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
-# TODO: Switch to UBI golang image when 1.19 is released
-# FROM registry.access.redhat.com/ubi8/go-toolset:latest
-
-WORKDIR /workspace
+FROM registry.access.redhat.com/ubi8/go-toolset:1.19 as builder
 
 # Copy the go source
 COPY main.go main.go
@@ -14,13 +10,11 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN GOOS=linux GOARCH=amd64 go build -tags strictfipsruntime -a -o /usr/bin/manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM registry.redhat.io/rhel8-6-els/rhel:latest
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /usr/bin/manager .
 
 USER 65532:65532
 

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,8 @@ IAMCTL_OUTPUT_MINIFY_CR_FILE ?= ./hack/controller/controller-credentials-request
 # Built go binary path.
 IAMCTL_BINARY ?= ./bin/iamctl
 
+CHECK_PAYLOAD_IMG ?= registry.ci.openshift.org/ci/check-payload:latest
+
 
 .PHONY: all
 all: build
@@ -189,10 +191,14 @@ image-build: build test ## Build container image with the manager.
 image-push: ## Push container image with the manager.
 	${CONTAINER_ENGINE} push ${IMG}
 
+.PHONY: image-fips-scan
+image-fips-scan: image-build image-push
+	$(CONTAINER_ENGINE) run --privileged $(CHECK_PAYLOAD_IMG) scan operator --spec $(IMG)
+
 .PHONY: iamctl-build
 iamctl-build: fmt vet ## Build iamctl binary.
 	mkdir -p ./bin
-	cd ./cmd/iamctl && go build -mod=vendor -o $(IAMCTL_BINARY) . 
+	cd ./cmd/iamctl && go build -mod=vendor -o $(IAMCTL_BINARY) .
 	mv ./cmd/iamctl/$(IAMCTL_BINARY) ./bin/
 
 ##@ Deployment


### PR DESCRIPTION
This commit addresses all the errors detected by [the check-payload tool](https://github.com/openshift/check-payload) by implementing the following changes:
- Replaced the base image with a non-UBI variant.
- Updated the builder image to be FIPS-capable.
- Enabled dynamic linkage for the operator binary (`CGO_ENABLED=1`).
- Added the `strictfipsruntime` tag to the operator binary.

Additionally, implemented `image-fips-scan` command for local FIPS compliance checks.

Result:
```
$ IMG=quay.io/alebedev/albo make image-fips-scan
sudo podman run --privileged registry.ci.openshift.org/ci/check-payload:latest scan operator --spec quay.io/alebedev/albo
I0326 08:50:55.098182       1 main.go:302] using embedded config
...
I0326 08:50:55.098589       1 main.go:102] "scan" version="0.3.1-91-ga0d1e0d3-dirty"
---- Successful run
```