### PR TITLE
fix: Add AWS ISO partitions to LB CRD

### DIFF
--- a/api/v1/awsloadbalancercontroller_types.go
+++ b/api/v1/awsloadbalancercontroller_types.go
@@ -177,7 +177,7 @@ type AWSLoadBalancerCredentialsRequestConfig struct {
 	// This ARN is added to AWSProviderSpec initiating the creation of a secret containing IAM
 	// Role details necessary for assuming the IAM Role via Amazon's Secure Token Service (STS).
 	//
-	// +kubebuilder:validation:Pattern:=`^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role\/.*$`
+	// +kubebuilder:validation:Pattern:=`^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):iam::[0-9]{12}:role\/.*$`
 	// +kubebuilder:validation:Optional
 	// +optional
 	STSIAMRoleARN string `json:"stsIAMRoleARN,omitempty"`

--- a/bundle/manifests/networking.olm.openshift.io_awsloadbalancercontrollers.yaml
+++ b/bundle/manifests/networking.olm.openshift.io_awsloadbalancercontrollers.yaml
@@ -132,7 +132,7 @@ spec:
                       the creation of a secret containing IAM Role details necessary
                       for assuming the IAM Role via Amazon's Secure Token Service
                       (STS).
-                    pattern: ^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role\/.*$
+                    pattern: ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):iam::[0-9]{12}:role\/.*$
                     type: string
                 type: object
               enabledAddons:

--- a/config/crd/bases/networking.olm.openshift.io_awsloadbalancercontrollers.yaml
+++ b/config/crd/bases/networking.olm.openshift.io_awsloadbalancercontrollers.yaml
@@ -123,7 +123,7 @@ spec:
                       the creation of a secret containing IAM Role details necessary
                       for assuming the IAM Role via Amazon's Secure Token Service
                       (STS).
-                    pattern: ^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role\/.*$
+                    pattern: ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):iam::[0-9]{12}:role\/.*$
                     type: string
                 type: object
               enabledAddons:


### PR DESCRIPTION
ISO partitions are missing from `stsIAMRoleARN` meaning that the operator cannot be used in these partitions in Manual credentials mode without manually modifying the CRD. 

Partitions taken from https://github.com/aws/aws-sdk-go-v2/blob/main/internal/endpoints/awsrulesfn/partitions.json