### PR TITLE
NE-1808: Bump controller to v2.8.2

### DIFF
--- a/assets/iam-policy.json
+++ b/assets/iam-policy.json
@@ -38,7 +38,8 @@
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetHealth",
-                "elasticloadbalancing:DescribeTags"
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:DescribeTrustStores"
             ],
             "Resource": "*"
         },

--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -287,7 +287,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_CONTROLLER
-                  value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:72a5057abe61e5e0de19cdaccba81326baf242bf087f74e10f303deeaae181a2
+                  value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:75c5e5c1c650b27c273875d6e9497ede335c0ded6719064b0db63a6da8369937
                 - name: TARGET_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/bundle/manifests/elbv2.k8s.aws_ingressclassparams.yaml
+++ b/bundle/manifests/elbv2.k8s.aws_ingressclassparams.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: ingressclassparams.elbv2.k8s.aws
 spec:
@@ -36,20 +36,31 @@ spec:
         description: IngressClassParams is the Schema for the IngressClassParams API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
             description: IngressClassParamsSpec defines the desired state of IngressClassParams
             properties:
+              certificateArn:
+                description: CertificateArn specifies the ARN of the certificates
+                  for all Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  type: string
+                type: array
               group:
                 description: Group defines the IngressGroup for all Ingresses that
                   belong to IngressClass with this IngressClassParams.
@@ -60,12 +71,19 @@ spec:
                 required:
                 - name
                 type: object
+              inboundCIDRs:
+                description: InboundCIDRs specifies the CIDRs that are allowed to
+                  access the Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  type: string
+                type: array
               ipAddressType:
                 description: IPAddressType defines the ip address type for all Ingresses
                   that belong to IngressClass with this IngressClassParams.
                 enum:
                 - ipv4
                 - dualstack
+                - dualstack-without-public-ipv4
                 type: string
               loadBalancerAttributes:
                 description: LoadBalancerAttributes define the custom attributes to
@@ -86,51 +104,53 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                description: NamespaceSelector restrict the namespaces of Ingresses
-                  that are allowed to specify the IngressClass with this IngressClassParams.
+                description: |-
+                  NamespaceSelector restrict the namespaces of Ingresses that are allowed to specify the IngressClass with this IngressClassParams.
                   * if absent or present but empty, it selects all namespaces.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               scheme:
                 description: Scheme defines the scheme for all Ingresses that belong
                   to IngressClass with this IngressClassParams.
@@ -138,6 +158,35 @@ spec:
                 - internal
                 - internet-facing
                 type: string
+              sslPolicy:
+                description: SSLPolicy specifies the SSL Policy for all Ingresses
+                  that belong to IngressClass with this IngressClassParams.
+                type: string
+              subnets:
+                description: Subnets defines the subnets for all Ingresses that belong
+                  to IngressClass with this IngressClassParams.
+                properties:
+                  ids:
+                    description: IDs specify the resource IDs of subnets. Exactly
+                      one of this or `tags` must be specified.
+                    items:
+                      description: SubnetID specifies a subnet ID.
+                      pattern: subnet-[0-9a-f]+
+                      type: string
+                    minItems: 1
+                    type: array
+                  tags:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: |-
+                      Tags specifies subnets in the load balancer's VPC where each
+                      tag specified in the map key contains one of the values in the corresponding
+                      value list.
+                      Exactly one of this or `ids` must be specified.
+                    type: object
+                type: object
               tags:
                 description: Tags defines list of Tags on AWS resources provisioned
                   for Ingresses that belong to IngressClass with this IngressClassParams.
@@ -164,5 +213,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/elbv2.k8s.aws_targetgroupbindings.yaml
+++ b/bundle/manifests/elbv2.k8s.aws_targetgroupbindings.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: targetgroupbindings.elbv2.k8s.aws
 spec:
@@ -41,14 +41,19 @@ spec:
         description: TargetGroupBinding is the Schema for the TargetGroupBinding API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -65,28 +70,30 @@ spec:
                     items:
                       properties:
                         from:
-                          description: List of peers which should be able to access
-                            the targets in TargetGroup. At least one NetworkingPeer
-                            should be specified.
+                          description: |-
+                            List of peers which should be able to access the targets in TargetGroup.
+                            At least one NetworkingPeer should be specified.
                           items:
                             description: NetworkingPeer defines the source/destination
                               peer for networking rules.
                             properties:
                               ipBlock:
-                                description: IPBlock defines an IPBlock peer. If specified,
-                                  none of the other fields can be set.
+                                description: |-
+                                  IPBlock defines an IPBlock peer.
+                                  If specified, none of the other fields can be set.
                                 properties:
                                   cidr:
-                                    description: CIDR is the network CIDR. Both IPV4
-                                      or IPV6 CIDR are accepted.
+                                    description: |-
+                                      CIDR is the network CIDR.
+                                      Both IPV4 or IPV6 CIDR are accepted.
                                     type: string
                                 required:
                                 - cidr
                                 type: object
                               securityGroup:
-                                description: SecurityGroup defines a SecurityGroup
-                                  peer. If specified, none of the other fields can
-                                  be set.
+                                description: |-
+                                  SecurityGroup defines a SecurityGroup peer.
+                                  If specified, none of the other fields can be set.
                                 properties:
                                   groupID:
                                     description: GroupID is the EC2 SecurityGroupID.
@@ -97,24 +104,24 @@ spec:
                             type: object
                           type: array
                         ports:
-                          description: List of ports which should be made accessible
-                            on the targets in TargetGroup. If ports is empty or unspecified,
-                            it defaults to all ports with TCP.
+                          description: |-
+                            List of ports which should be made accessible on the targets in TargetGroup.
+                            If ports is empty or unspecified, it defaults to all ports with TCP.
                           items:
                             properties:
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: The port which traffic must match. When
-                                  NodePort endpoints(instance TargetType) is used,
-                                  this must be a numerical port. When Port endpoints(ip
-                                  TargetType) is used, this can be either numerical
-                                  or named port on pods. if port is unspecified, it
-                                  defaults to all ports.
+                                description: |-
+                                  The port which traffic must match.
+                                  When NodePort endpoints(instance TargetType) is used, this must be a numerical port.
+                                  When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods.
+                                  if port is unspecified, it defaults to all ports.
                                 x-kubernetes-int-or-string: true
                               protocol:
-                                description: The protocol which traffic must match.
+                                description: |-
+                                  The protocol which traffic must match.
                                   If protocol is unspecified, it defaults to TCP.
                                 enum:
                                 - TCP
@@ -200,14 +207,19 @@ spec:
         description: TargetGroupBinding is the Schema for the TargetGroupBinding API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -233,28 +245,30 @@ spec:
                         of traffic that is allowed to access TargetGroup's targets.
                       properties:
                         from:
-                          description: List of peers which should be able to access
-                            the targets in TargetGroup. At least one NetworkingPeer
-                            should be specified.
+                          description: |-
+                            List of peers which should be able to access the targets in TargetGroup.
+                            At least one NetworkingPeer should be specified.
                           items:
                             description: NetworkingPeer defines the source/destination
                               peer for networking rules.
                             properties:
                               ipBlock:
-                                description: IPBlock defines an IPBlock peer. If specified,
-                                  none of the other fields can be set.
+                                description: |-
+                                  IPBlock defines an IPBlock peer.
+                                  If specified, none of the other fields can be set.
                                 properties:
                                   cidr:
-                                    description: CIDR is the network CIDR. Both IPV4
-                                      or IPV6 CIDR are accepted.
+                                    description: |-
+                                      CIDR is the network CIDR.
+                                      Both IPV4 or IPV6 CIDR are accepted.
                                     type: string
                                 required:
                                 - cidr
                                 type: object
                               securityGroup:
-                                description: SecurityGroup defines a SecurityGroup
-                                  peer. If specified, none of the other fields can
-                                  be set.
+                                description: |-
+                                  SecurityGroup defines a SecurityGroup peer.
+                                  If specified, none of the other fields can be set.
                                 properties:
                                   groupID:
                                     description: GroupID is the EC2 SecurityGroupID.
@@ -265,9 +279,9 @@ spec:
                             type: object
                           type: array
                         ports:
-                          description: List of ports which should be made accessible
-                            on the targets in TargetGroup. If ports is empty or unspecified,
-                            it defaults to all ports with TCP.
+                          description: |-
+                            List of ports which should be made accessible on the targets in TargetGroup.
+                            If ports is empty or unspecified, it defaults to all ports with TCP.
                           items:
                             description: NetworkingPort defines the port and protocol
                               for networking rules.
@@ -276,15 +290,15 @@ spec:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: The port which traffic must match. When
-                                  NodePort endpoints(instance TargetType) is used,
-                                  this must be a numerical port. When Port endpoints(ip
-                                  TargetType) is used, this can be either numerical
-                                  or named port on pods. if port is unspecified, it
-                                  defaults to all ports.
+                                description: |-
+                                  The port which traffic must match.
+                                  When NodePort endpoints(instance TargetType) is used, this must be a numerical port.
+                                  When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods.
+                                  if port is unspecified, it defaults to all ports.
                                 x-kubernetes-int-or-string: true
                               protocol:
-                                description: The protocol which traffic must match.
+                                description: |-
+                                  The protocol which traffic must match.
                                   If protocol is unspecified, it defaults to TCP.
                                 enum:
                                 - TCP
@@ -306,43 +320,45 @@ spec:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               serviceRef:
                 description: serviceRef is a reference to a Kubernetes Service and
                   ServicePort.
@@ -372,6 +388,10 @@ spec:
                 - instance
                 - ip
                 type: string
+              vpcID:
+                description: VpcID is the VPC of the TargetGroup. If unspecified,
+                  it will be automatically inferred.
+                type: string
             required:
             - serviceRef
             - targetGroupARN
@@ -393,5 +413,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
+++ b/config/crd/bases/elbv2.k8s.aws_ingressclassparams.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: ingressclassparams.elbv2.k8s.aws
 spec:
   group: elbv2.k8s.aws
@@ -38,18 +36,34 @@ spec:
         description: IngressClassParams is the Schema for the IngressClassParams API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
             description: IngressClassParamsSpec defines the desired state of IngressClassParams
             properties:
+              certificateArn:
+                description: CertificateArn specifies the ARN of the certificates
+                  for all Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  type: string
+                type: array
               group:
-                description: Group defines the IngressGroup for all Ingresses that belong to IngressClass with this IngressClassParams.
+                description: Group defines the IngressGroup for all Ingresses that
+                  belong to IngressClass with this IngressClassParams.
                 properties:
                   name:
                     description: Name is the name of IngressGroup.
@@ -57,14 +71,24 @@ spec:
                 required:
                 - name
                 type: object
+              inboundCIDRs:
+                description: InboundCIDRs specifies the CIDRs that are allowed to
+                  access the Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  type: string
+                type: array
               ipAddressType:
-                description: IPAddressType defines the ip address type for all Ingresses that belong to IngressClass with this IngressClassParams.
+                description: IPAddressType defines the ip address type for all Ingresses
+                  that belong to IngressClass with this IngressClassParams.
                 enum:
                 - ipv4
                 - dualstack
+                - dualstack-without-public-ipv4
                 type: string
               loadBalancerAttributes:
-                description: LoadBalancerAttributes define the custom attributes to LoadBalancers for all Ingress that that belong to IngressClass with this IngressClassParams.
+                description: LoadBalancerAttributes define the custom attributes to
+                  LoadBalancers for all Ingress that that belong to IngressClass with
+                  this IngressClassParams.
                 items:
                   description: Attributes defines custom attributes on resources.
                   properties:
@@ -80,43 +104,92 @@ spec:
                   type: object
                 type: array
               namespaceSelector:
-                description: NamespaceSelector restrict the namespaces of Ingresses that are allowed to specify the IngressClass with this IngressClassParams. * if absent or present but empty, it selects all namespaces.
+                description: |-
+                  NamespaceSelector restrict the namespaces of Ingresses that are allowed to specify the IngressClass with this IngressClassParams.
+                  * if absent or present but empty, it selects all namespaces.
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies to.
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               scheme:
-                description: Scheme defines the scheme for all Ingresses that belong to IngressClass with this IngressClassParams.
+                description: Scheme defines the scheme for all Ingresses that belong
+                  to IngressClass with this IngressClassParams.
                 enum:
                 - internal
                 - internet-facing
                 type: string
+              sslPolicy:
+                description: SSLPolicy specifies the SSL Policy for all Ingresses
+                  that belong to IngressClass with this IngressClassParams.
+                type: string
+              subnets:
+                description: Subnets defines the subnets for all Ingresses that belong
+                  to IngressClass with this IngressClassParams.
+                properties:
+                  ids:
+                    description: IDs specify the resource IDs of subnets. Exactly
+                      one of this or `tags` must be specified.
+                    items:
+                      description: SubnetID specifies a subnet ID.
+                      pattern: subnet-[0-9a-f]+
+                      type: string
+                    minItems: 1
+                    type: array
+                  tags:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: |-
+                      Tags specifies subnets in the load balancer's VPC where each
+                      tag specified in the map key contains one of the values in the corresponding
+                      value list.
+                      Exactly one of this or `ids` must be specified.
+                    type: object
+                type: object
               tags:
-                description: Tags defines list of Tags on AWS resources provisioned for Ingresses that belong to IngressClass with this IngressClassParams.
+                description: Tags defines list of Tags on AWS resources provisioned
+                  for Ingresses that belong to IngressClass with this IngressClassParams.
                 items:
                   description: Tag defines a AWS Tag on resources.
                   properties:
@@ -136,9 +209,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/elbv2.k8s.aws_targetgroupbindings.yaml
+++ b/config/crd/bases/elbv2.k8s.aws_targetgroupbindings.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: targetgroupbindings.elbv2.k8s.aws
 spec:
   group: elbv2.k8s.aws
@@ -43,10 +41,19 @@ spec:
         description: TargetGroupBinding is the Schema for the TargetGroupBinding API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -54,28 +61,39 @@ spec:
             description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
             properties:
               networking:
-                description: networking provides the networking setup for ELBV2 LoadBalancer to access targets in TargetGroup.
+                description: networking provides the networking setup for ELBV2 LoadBalancer
+                  to access targets in TargetGroup.
                 properties:
                   ingress:
-                    description: List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                    description: List of ingress rules to allow ELBV2 LoadBalancer
+                      to access targets in TargetGroup.
                     items:
                       properties:
                         from:
-                          description: List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.
+                          description: |-
+                            List of peers which should be able to access the targets in TargetGroup.
+                            At least one NetworkingPeer should be specified.
                           items:
-                            description: NetworkingPeer defines the source/destination peer for networking rules.
+                            description: NetworkingPeer defines the source/destination
+                              peer for networking rules.
                             properties:
                               ipBlock:
-                                description: IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.
+                                description: |-
+                                  IPBlock defines an IPBlock peer.
+                                  If specified, none of the other fields can be set.
                                 properties:
                                   cidr:
-                                    description: CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.
+                                    description: |-
+                                      CIDR is the network CIDR.
+                                      Both IPV4 or IPV6 CIDR are accepted.
                                     type: string
                                 required:
                                 - cidr
                                 type: object
                               securityGroup:
-                                description: SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.
+                                description: |-
+                                  SecurityGroup defines a SecurityGroup peer.
+                                  If specified, none of the other fields can be set.
                                 properties:
                                   groupID:
                                     description: GroupID is the EC2 SecurityGroupID.
@@ -86,17 +104,25 @@ spec:
                             type: object
                           type: array
                         ports:
-                          description: List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.
+                          description: |-
+                            List of ports which should be made accessible on the targets in TargetGroup.
+                            If ports is empty or unspecified, it defaults to all ports with TCP.
                           items:
                             properties:
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.
+                                description: |-
+                                  The port which traffic must match.
+                                  When NodePort endpoints(instance TargetType) is used, this must be a numerical port.
+                                  When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods.
+                                  if port is unspecified, it defaults to all ports.
                                 x-kubernetes-int-or-string: true
                               protocol:
-                                description: The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.
+                                description: |-
+                                  The protocol which traffic must match.
+                                  If protocol is unspecified, it defaults to TCP.
                                 enum:
                                 - TCP
                                 - UDP
@@ -110,7 +136,8 @@ spec:
                     type: array
                 type: object
               serviceRef:
-                description: serviceRef is a reference to a Kubernetes Service and ServicePort.
+                description: serviceRef is a reference to a Kubernetes Service and
+                  ServicePort.
                 properties:
                   name:
                     description: Name is the name of the Service.
@@ -126,10 +153,12 @@ spec:
                 - port
                 type: object
               targetGroupARN:
-                description: targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.
+                description: targetGroupARN is the Amazon Resource Name (ARN) for
+                  the TargetGroup.
                 type: string
               targetType:
-                description: targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.
+                description: targetType is the TargetType of TargetGroup. If unspecified,
+                  it will be automatically inferred.
                 enum:
                 - instance
                 - ip
@@ -178,10 +207,19 @@ spec:
         description: TargetGroupBinding is the Schema for the TargetGroupBinding API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -189,35 +227,48 @@ spec:
             description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
             properties:
               ipAddressType:
-                description: ipAddressType specifies whether the target group is of type IPv4 or IPv6. If unspecified, it will be automatically inferred.
+                description: ipAddressType specifies whether the target group is of
+                  type IPv4 or IPv6. If unspecified, it will be automatically inferred.
                 enum:
                 - ipv4
                 - ipv6
                 type: string
               networking:
-                description: networking defines the networking rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                description: networking defines the networking rules to allow ELBV2
+                  LoadBalancer to access targets in TargetGroup.
                 properties:
                   ingress:
-                    description: List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                    description: List of ingress rules to allow ELBV2 LoadBalancer
+                      to access targets in TargetGroup.
                     items:
-                      description: NetworkingIngressRule defines a particular set of traffic that is allowed to access TargetGroup's targets.
+                      description: NetworkingIngressRule defines a particular set
+                        of traffic that is allowed to access TargetGroup's targets.
                       properties:
                         from:
-                          description: List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.
+                          description: |-
+                            List of peers which should be able to access the targets in TargetGroup.
+                            At least one NetworkingPeer should be specified.
                           items:
-                            description: NetworkingPeer defines the source/destination peer for networking rules.
+                            description: NetworkingPeer defines the source/destination
+                              peer for networking rules.
                             properties:
                               ipBlock:
-                                description: IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.
+                                description: |-
+                                  IPBlock defines an IPBlock peer.
+                                  If specified, none of the other fields can be set.
                                 properties:
                                   cidr:
-                                    description: CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.
+                                    description: |-
+                                      CIDR is the network CIDR.
+                                      Both IPV4 or IPV6 CIDR are accepted.
                                     type: string
                                 required:
                                 - cidr
                                 type: object
                               securityGroup:
-                                description: SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.
+                                description: |-
+                                  SecurityGroup defines a SecurityGroup peer.
+                                  If specified, none of the other fields can be set.
                                 properties:
                                   groupID:
                                     description: GroupID is the EC2 SecurityGroupID.
@@ -228,18 +279,27 @@ spec:
                             type: object
                           type: array
                         ports:
-                          description: List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.
+                          description: |-
+                            List of ports which should be made accessible on the targets in TargetGroup.
+                            If ports is empty or unspecified, it defaults to all ports with TCP.
                           items:
-                            description: NetworkingPort defines the port and protocol for networking rules.
+                            description: NetworkingPort defines the port and protocol
+                              for networking rules.
                             properties:
                               port:
                                 anyOf:
                                 - type: integer
                                 - type: string
-                                description: The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.
+                                description: |-
+                                  The port which traffic must match.
+                                  When NodePort endpoints(instance TargetType) is used, this must be a numerical port.
+                                  When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods.
+                                  if port is unspecified, it defaults to all ports.
                                 x-kubernetes-int-or-string: true
                               protocol:
-                                description: The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.
+                                description: |-
+                                  The protocol which traffic must match.
+                                  If protocol is unspecified, it defaults to TCP.
                                 enum:
                                 - TCP
                                 - UDP
@@ -253,37 +313,55 @@ spec:
                     type: array
                 type: object
               nodeSelector:
-                description: node selector for instance type target groups to only register certain nodes
+                description: node selector for instance type target groups to only
+                  register certain nodes
                 properties:
                   matchExpressions:
-                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
-                          description: key is the label key that the selector applies to.
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                       required:
                       - key
                       - operator
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               serviceRef:
-                description: serviceRef is a reference to a Kubernetes Service and ServicePort.
+                description: serviceRef is a reference to a Kubernetes Service and
+                  ServicePort.
                 properties:
                   name:
                     description: Name is the name of the Service.
@@ -299,14 +377,20 @@ spec:
                 - port
                 type: object
               targetGroupARN:
-                description: targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.
+                description: targetGroupARN is the Amazon Resource Name (ARN) for
+                  the TargetGroup.
                 minLength: 1
                 type: string
               targetType:
-                description: targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.
+                description: targetType is the TargetType of TargetGroup. If unspecified,
+                  it will be automatically inferred.
                 enum:
                 - instance
                 - ip
+                type: string
+              vpcID:
+                description: VpcID is the VPC of the TargetGroup. If unspecified,
+                  it will be automatically inferred.
                 type: string
             required:
             - serviceRef
@@ -325,9 +409,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,9 +77,9 @@ spec:
             memory: 64Mi
         env:
           - name: RELATED_IMAGE_CONTROLLER
-            # openshift/aws-load-balancer-controller commit: 105552ef8dc36f69988448e14a1ac46d3223fbb9
-            # manifest link: https://quay.io/repository/aws-load-balancer-operator/aws-load-balancer-controller/manifest/sha256:72a5057abe61e5e0de19cdaccba81326baf242bf087f74e10f303deeaae181a2
-            value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:72a5057abe61e5e0de19cdaccba81326baf242bf087f74e10f303deeaae181a2
+            # openshift/aws-load-balancer-controller commit: 970ea56f31a3e660efbbed1deb50bf5ed9262c92
+            # manifest link: https://quay.io/repository/aws-load-balancer-operator/aws-load-balancer-controller/manifest/sha256:75c5e5c1c650b27c273875d6e9497ede335c0ded6719064b0db63a6da8369937
+            value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:75c5e5c1c650b27c273875d6e9497ede335c0ded6719064b0db63a6da8369937
           - name: TARGET_NAMESPACE
             valueFrom:
               fieldRef:

--- a/config/rbac/upstream_role.yaml
+++ b/config/rbac/upstream_role.yaml
@@ -1,9 +1,7 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: controller-role
 rules:
 - apiGroups:

--- a/hack/controller/controller-credentials-request.yaml
+++ b/hack/controller/controller-credentials-request.yaml
@@ -39,6 +39,7 @@ spec:
       - elasticloadbalancing:DescribeTargetGroupAttributes
       - elasticloadbalancing:DescribeTargetHealth
       - elasticloadbalancing:DescribeTags
+      - elasticloadbalancing:DescribeTrustStores
       effect: Allow
       resource: "*"
     - action:

--- a/pkg/controllers/awsloadbalancercontroller/iam_policy.go
+++ b/pkg/controllers/awsloadbalancercontroller/iam_policy.go
@@ -50,6 +50,7 @@ func GetIAMPolicy() IAMPolicy {
 					"elasticloadbalancing:DescribeTargetGroupAttributes",
 					"elasticloadbalancing:DescribeTargetHealth",
 					"elasticloadbalancing:DescribeTags",
+					"elasticloadbalancing:DescribeTrustStores",
 				},
 			},
 			{

--- a/pkg/controllers/awsloadbalancercontroller/rbac_rules.go
+++ b/pkg/controllers/awsloadbalancercontroller/rbac_rules.go
@@ -16,5 +16,16 @@ func getLeaderElectionRules() []rbacv1.PolicyRule {
 			ResourceNames: []string{"aws-load-balancer-controller-leader"},
 			Verbs:         []string{"get", "update", "patch"},
 		},
+		{
+			APIGroups: []string{"coordination.k8s.io"},
+			Resources: []string{"leases"},
+			Verbs:     []string{"create"},
+		},
+		{
+			APIGroups:     []string{"coordination.k8s.io"},
+			Resources:     []string{"leases"},
+			ResourceNames: []string{"aws-load-balancer-controller-leader"},
+			Verbs:         []string{"get", "update", "patch"},
+		},
 	}
 }


### PR DESCRIPTION
- Updated controller image to the latest version from downstream.
- Re-generated operator bundle using `make bundle`, which also updated controller CRDs.
- Synced IAM policy with the latest downstream version.
- Re-generated managed IAM policy and credentials request using `make generate`.
- Updated managed controller RBAC to include permissions for leases.
  - Note: Controller-runtime no longer supports ConfigMaps for leader election.
  
Integrates https://github.com/openshift/aws-load-balancer-controller/pull/23 into the operator.