### PR TITLE
hack: flag to sync crds and rbac from k8s upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,8 @@ IAMCTL_BINARY ?= ./bin/iamctl
 
 CHECK_PAYLOAD_IMG ?= registry.ci.openshift.org/ci/check-payload:latest
 
+SYNC_ARGS ?= ""
+
 
 .PHONY: all
 all: build
@@ -123,8 +125,8 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	hack/sync-upstream-crds.sh
-	hack/sync-upstream-rbac.sh
+	hack/sync-upstream-crds.sh $(SYNC_ARGS)
+	hack/sync-upstream-rbac.sh $(SYNC_ARGS)
 
 .PHONY: generate
 generate: iamctl-gen iam-gen## Generate code containing DeepCopy, DeepCopyInto, DeepCopyObject method implementations and iamctl policies.

--- a/hack/sync-upstream-crds.sh
+++ b/hack/sync-upstream-crds.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
-UPSTREAM="https://raw.githubusercontent.com/openshift/aws-load-balancer-controller/main/config/crd/bases"
+ORG="openshift"
+if [[ $# -gt 0 && "${1}" == "-k" ]]; then
+    # Sync with Kubernetes upstream to enable testing of unmerged controller rebase PRs.
+    ORG="kubernetes-sigs"
+fi
+UPSTREAM="https://raw.githubusercontent.com/${ORG}/aws-load-balancer-controller/main/config/crd/bases"
 INGRESS_CLASS_PARAMS="elbv2.k8s.aws_ingressclassparams.yaml"
 TARGET_GROUP_BINDINGS="elbv2.k8s.aws_targetgroupbindings.yaml"
 OUTPUT_DIR=config/crd/bases
 
-curl --silent --output "$OUTPUT_DIR/$INGRESS_CLASS_PARAMS" "$UPSTREAM/$INGRESS_CLASS_PARAMS"
-curl --silent --output "$OUTPUT_DIR/$TARGET_GROUP_BINDINGS" "$UPSTREAM/$TARGET_GROUP_BINDINGS"
+curl --output "$OUTPUT_DIR/$INGRESS_CLASS_PARAMS" "$UPSTREAM/$INGRESS_CLASS_PARAMS"
+curl --output "$OUTPUT_DIR/$TARGET_GROUP_BINDINGS" "$UPSTREAM/$TARGET_GROUP_BINDINGS"

--- a/hack/sync-upstream-rbac.sh
+++ b/hack/sync-upstream-rbac.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
-UPSTREAM="https://raw.githubusercontent.com/openshift/aws-load-balancer-controller/main/config/rbac"
+ORG="openshift"
+if [[ $# -gt 0 && "${1}" == "-k" ]]; then
+    # Sync with Kubernetes upstream to enable testing of unmerged controller rebase PRs.
+    ORG="kubernetes-sigs"
+fi
+UPSTREAM="https://raw.githubusercontent.com/${ORG}/aws-load-balancer-controller/main/config/rbac"
 CONTROLLER_ROLE="role.yaml"
 
 ## Output ENV
@@ -9,4 +14,4 @@ YQ_BIN="go run github.com/mikefarah/yq/v4"
 OUTPUT_DIR=config/rbac
 OUTPUT_PREFIX=upstream_
 
-curl --silent --output "$OUTPUT_DIR/$OUTPUT_PREFIX$CONTROLLER_ROLE" "$UPSTREAM/$CONTROLLER_ROLE"
+curl --output "$OUTPUT_DIR/$OUTPUT_PREFIX$CONTROLLER_ROLE" "$UPSTREAM/$CONTROLLER_ROLE"


### PR DESCRIPTION
This commit enables testing of unmerged controller rebase PRs.