### PR TITLE
NE-2064: Update controller image to latest available

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -287,7 +287,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_CONTROLLER
-                  value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:75c5e5c1c650b27c273875d6e9497ede335c0ded6719064b0db63a6da8369937
+                  value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:78970d3ab5996d688a41c1cd21fcb5043d08c81c84ed963a16bfddc217c571cb
                 - name: TARGET_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,9 +77,9 @@ spec:
             memory: 64Mi
         env:
           - name: RELATED_IMAGE_CONTROLLER
-            # openshift/aws-load-balancer-controller commit: 970ea56f31a3e660efbbed1deb50bf5ed9262c92
-            # manifest link: https://quay.io/repository/aws-load-balancer-operator/aws-load-balancer-controller/manifest/sha256:75c5e5c1c650b27c273875d6e9497ede335c0ded6719064b0db63a6da8369937
-            value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:75c5e5c1c650b27c273875d6e9497ede335c0ded6719064b0db63a6da8369937
+            # openshift/aws-load-balancer-controller commit: d58fdf6a6b049d6dd779435364f6fb238d1aa755
+            # manifest link: https://quay.io/repository/aws-load-balancer-operator/aws-load-balancer-controller/manifest/sha256:78970d3ab5996d688a41c1cd21fcb5043d08c81c84ed963a16bfddc217c571cb
+            value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:78970d3ab5996d688a41c1cd21fcb5043d08c81c84ed963a16bfddc217c571cb
           - name: TARGET_NAMESPACE
             valueFrom:
               fieldRef:


### PR DESCRIPTION
Update the controller image reference in the operator manifests to the latest version available at quay.io/aws-load-balancer-operator/aws-load-balancer-controller. The previous image was pruned by quay.io and is no longer available for pull.

Related question in forum-ocp-testplatform: [link](https://redhat-internal.slack.com/archives/CBN38N3MW/p1749594215180509).
Quay.io question about pruning: [link](https://redhat-internal.slack.com/archives/C7WH69HCY/p1749594852800799).