### PR TITLE
OCPBUGS-57339: Use floating tag for controller image

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -287,7 +287,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_CONTROLLER
-                  value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:78970d3ab5996d688a41c1cd21fcb5043d08c81c84ed963a16bfddc217c571cb
+                  value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller:latest
                 - name: TARGET_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -77,9 +77,9 @@ spec:
             memory: 64Mi
         env:
           - name: RELATED_IMAGE_CONTROLLER
-            # openshift/aws-load-balancer-controller commit: d58fdf6a6b049d6dd779435364f6fb238d1aa755
-            # manifest link: https://quay.io/repository/aws-load-balancer-operator/aws-load-balancer-controller/manifest/sha256:78970d3ab5996d688a41c1cd21fcb5043d08c81c84ed963a16bfddc217c571cb
-            value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller@sha256:78970d3ab5996d688a41c1cd21fcb5043d08c81c84ed963a16bfddc217c571cb
+            # Use "latest" floating tag to avoid problems with the prunning of older mirorred images.
+            # Ref: https://issues.redhat.com/browse/OCPBUGS-57339.
+            value: quay.io/aws-load-balancer-operator/aws-load-balancer-controller:latest
           - name: TARGET_NAMESPACE
             valueFrom:
               fieldRef:


### PR DESCRIPTION
This commit changes the strategy used to reference the controller image in the operator's deployment manifest. The `latest` floating tag is now used to avoid issues with older mirrored images being removed.

Since these manifests are used only in CI presubmits, there is no risk of breaking future releases, which will have pinned versions (SHA256 digests) for all images.