### PR TITLE
NE-2064: Fix HasLicense pipeline build warning

### DIFF
--- a/Containerfile.aws-load-balancer-operator
+++ b/Containerfile.aws-load-balancer-operator
@@ -17,6 +17,7 @@ WORKDIR /workspace
 # Build
 RUN GOOS=linux GOARCH=amd64 go build -tags strictfipsruntime -a -o /usr/bin/manager main.go
 
+COPY LICENSE /licenses/
 FROM registry.redhat.io/rhel8-6-els/rhel:8.6-1737
 LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="aws-load-balancer-operator-container"


### PR DESCRIPTION
This commit fixes the Ecosystem-cert-preflight-checks test where it fails for HasLicense. This is done by creating a directory at root of repo for /licenses.
