### PR TITLE
NE-2064: Fix HasLicense pipeline build warning (#170)

### DIFF
--- a/Containerfile.aws-load-balancer-operator
+++ b/Containerfile.aws-load-balancer-operator
@@ -25,4 +25,5 @@ LABEL version="1.2.0"
 WORKDIR /
 COPY --from=builder /usr/bin/manager /manager
 USER 65532:65532
+COPY LICENSE /licenses/
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
This commit fixes the Ecosystem-cert-preflight-checks test where it fails for HasLicense. This is done by creating the licenses directory at the root of the image