### PR TITLE
NE-2064: Update base and builder images to UBI9

### DIFF
--- a/Containerfile.aws-load-balancer-operator
+++ b/Containerfile.aws-load-balancer-operator
@@ -1,5 +1,5 @@
 # Detect the drift from the upstream Dockerfile
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS drift
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS drift
 WORKDIR /app
 COPY drift-cache/Dockerfile Dockerfile.cached
 COPY Dockerfile .
@@ -8,22 +8,30 @@ COPY Dockerfile .
 # drift-cache/Dockerfile can be updated with the upstream contents once the Konflux version is aligned.
 RUN test "$(sha1sum Dockerfile.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile | cut -d' ' -f1)"
 
-
-FROM registry.access.redhat.com/ubi8/go-toolset:1.22 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22 as builder
 # dummy copy to trigger the drift detection
 COPY --from=drift /app/Dockerfile.cached .
-COPY . /workspace
-WORKDIR /workspace
-# Build
-RUN GOOS=linux GOARCH=amd64 go build -tags strictfipsruntime -a -o /usr/bin/manager main.go
 
-FROM registry.redhat.io/rhel8-6-els/rhel:8.6-1737
+WORKDIR /workspace
+# Dummy RUN to create /workspace directory.
+# WORKDIR doesn't create the directory (at least for Podman).
+# Without this step, the following COPY may create /workspace
+# as root-owned (instead of go-toolset's default 1001)
+# leading to "Permission denied" errors during "go build"
+# when trying to write output.
+RUN ls .
+COPY . /workspace
+
+# Build
+RUN GOOS=linux GOARCH=amd64 go build -tags strictfipsruntime -a -o manager main.go
+
+FROM registry.access.redhat.com/ubi9/ubi:9.6-1751287003
 LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="aws-load-balancer-operator-container"
 LABEL name="aws-load-balancer-operator"
 LABEL version="1.2.0"
 WORKDIR /
-COPY --from=builder /usr/bin/manager /manager
+COPY --from=builder /workspace/manager /
 USER 65532:65532
 COPY LICENSE /licenses/
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
The RHEL ELS image had limited use and was previously chosen because UBI was not FIPS-ready. Now, UBI is the recommended base image for all customer-facing container images. It is also the most popular base image in Konflux.

UBI9 version was chosen to avoid fixable vulnerabilities of UBI8.

Changes to the work directories made due to container user permissions.