### PR TITLE
NE-2064: Add runAsNonRoot to kube-rbac-proxy container

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -274,6 +274,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  runAsNonRoot: true
                 terminationMessagePolicy: FallbackToLogsOnError
               - args:
                 - --health-probe-bind-address=:8081

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -26,6 +26,7 @@ spec:
           capabilities:
             drop:
               - ALL
+          runAsNonRoot: true
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
This commit adds the `runAsNonRoot` field to the kube-rbac-proxy container in the operator deployment, preventing it from running as root and addressing the general Coverity warning: "The Kubernetes container is allowed to run as the root user."