### PR TITLE
NE-2074: Configure Renovate updates of images, go-toolset and CVEs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": ["dockerfile", "gomod"],
+  "packageRules": [
+    {
+      "description": "Disable all Dockerfile updates by default. Only specific files will get targeted.",
+      "matchManagers": ["dockerfile"],
+      "enabled": false
+    },
+    {
+      "description": "Enable Docker image updates for Red Hat UBI images on major version 9",
+      "matchManagers": ["dockerfile"],
+      "matchFileNames": [
+        "Containerfile.aws-load-balancer-operator",
+        "Dockerfile",
+        "drift-cache/Dockerfile"
+      ],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "registry.access.redhat.com/ubi9/ubi-minimal",
+        "registry.access.redhat.com/ubi9/ubi"
+      ],
+      "enabled": true,
+      "versioning": "redhat",
+      "allowedVersions": "/^9(\\.|$)/"
+    },
+    {
+      "description": "Keep Go toolset on minor version 1.22",
+      "matchManagers": ["dockerfile"],
+      "matchFileNames": [
+        "Containerfile.aws-load-balancer-operator",
+        "Dockerfile",
+        "drift-cache/Dockerfile"
+      ],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "registry.access.redhat.com/ubi9/go-toolset"
+      ],
+      "enabled": true,
+      "versioning": "redhat",
+      "allowedVersions": "/^1\\.22(\\.|$)/"
+    },
+    {
+      "description": "Disable regular Go module updates, only allow vulnerability alerts",
+      "matchManagers": ["gomod"],
+      "enabled": false
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true
+}


### PR DESCRIPTION
Add Renovate/MintMaker configuration which:

- Configures base and builder images updates restricted to be only within the major version 9.
- go-toolset version updates restricted to be within the minor version 1.22.
- Disables go module updates except for CVE related ones.

Explicitly uses only `gomod` and `dockerfile` dependency managers for the above, as the other updates would be carried from upstream.

Renovate docs for the relevant fields and configurations:

- [packageRules](https://docs.renovatebot.com/configuration-options/#packagerules)
- [vulnerabilityAlerts](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts)
- [osvVulnerabilityAlerts](https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts)
- [Red Hat Versioning](https://docs.renovatebot.com/modules/versioning/redhat/)

[Dry run](https://docs.renovatebot.com/self-hosted-configuration/#dryrun) testing done using the `renovate` CLI npm package:
```bash
LOG_LEVEL=debug npx renovate@41.49.1 --token $GITHUB_TOKEN --dry-run=full grzpiotrowski/aws-load-balancer-operator
```