### PR TITLE
Ensure tekton pipeline triggered only on source repository

### DIFF
--- a/.tekton/aws-lb-bundle-container-aws-lb-optr-1-2-rhel-9-pull-request.yaml
+++ b/.tekton/aws-lb-bundle-container-aws-lb-optr-1-2-rhel-9-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && body.repository.full_name == "openshift/aws-load-balancer-operator"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: aws-lb-optr-1-2-rhel-9

--- a/.tekton/aws-lb-bundle-container-aws-lb-optr-1-2-rhel-9-push.yaml
+++ b/.tekton/aws-lb-bundle-container-aws-lb-optr-1-2-rhel-9-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && body.repository.full_name == "openshift/aws-load-balancer-operator"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: aws-lb-optr-1-2-rhel-9

--- a/.tekton/aws-load-balancer-operator-container-aws-lb-optr-1-2-rhel-9-pull-request.yaml
+++ b/.tekton/aws-load-balancer-operator-container-aws-lb-optr-1-2-rhel-9-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && body.repository.full_name == "openshift/aws-load-balancer-operator"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: aws-lb-optr-1-2-rhel-9

--- a/.tekton/aws-load-balancer-operator-container-aws-lb-optr-1-2-rhel-9-push.yaml
+++ b/.tekton/aws-load-balancer-operator-container-aws-lb-optr-1-2-rhel-9-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && body.repository.full_name == "openshift/aws-load-balancer-operator"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: aws-lb-optr-1-2-rhel-9


### PR DESCRIPTION
Previously the tekton pipelines could be triggered from the events on a forked aws-load-balancer-operator repository if the Red Hat Konflux app was also enabled on that fork, for example for testing.
For the operator, this would cause a new image build from the fork and the bundle-hack/container_digest.sh file to be nudged in the source repository with the image digest from that fork's build.

This PR adds a check of the repository name in on-cel-expression to ensure that the pipelines are triggered only by events on the `openshift/aws-load-balancer-operator` repository.