### PR TITLE
NE-2063: Prevent CSV replaces across minor channels

### DIFF
--- a/bundle-hack/bundle_vars.sh
+++ b/bundle-hack/bundle_vars.sh
@@ -8,7 +8,5 @@ export SUPPORTED_OCP_VERSIONS="${SUPPORTED_OCP_VERSIONS:-v4.17}"
 if [ -z "${REPLACES_VERSION:-}" ] && [ -n "${VERSION:-}" ]; then
   if [ "${VERSION##*.}" -ne 0 ]; then
     export REPLACES_VERSION="${VERSION%.*}.$((${VERSION##*.} - 1))"
-  else
-    export REPLACES_VERSION="1.1.1"
   fi
 fi

--- a/bundle-hack/update_bundle.sh
+++ b/bundle-hack/update_bundle.sh
@@ -7,8 +7,7 @@
 set -x
 set -e
 
-VERSION=$(cat VERSION)
-export VERSION
+export VERSION=$(cat VERSION)
 
 source ./container_digest.sh
 source ./bundle_vars.sh


### PR DESCRIPTION
If `VERSION` ends with `.0`, it represents the first release in a new minor channel. Such a release must not replace a version from a different minor channel. This behavior was already enforced by CPaaS bundle checks, so we now align with that rule here.