### PR TITLE
NE-2063: Fix the kube-rbac-proxy pullspec when updating CSV

### DIFF
--- a/bundle-hack/update_bundle.sh
+++ b/bundle-hack/update_bundle.sh
@@ -38,8 +38,8 @@ sed -i -e "s|openshift.io/aws-load-balancer-operator:latest|${OPERATOR_IMAGE_PUL
        -e "s|docker.io/amazon/aws-alb-ingress-controller:.*$|${OPERAND_IMAGE_PULLSPEC}|g" \
        -e "s|quay.io/aws-load-balancer-operator/aws-load-balancer-controller:.*$|${OPERAND_IMAGE_PULLSPEC}|g" \
        -e "s|quay.io/aws-load-balancer-operator/aws-load-balancer-controller@.*$|${OPERAND_IMAGE_PULLSPEC}|g" \
-       -e "s|gcr.io/kubebuilder/kube-rbac-proxy:.*$|registry.redhat.io/openshift4/ose-kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_PULLSPEC}|g" \
-       -e "s|quay.io/openshift/origin-kube-rbac-proxy:.*$|registry.redhat.io/openshift4/ose-kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_PULLSPEC}|g" "${CSV_FILE}"
+       -e "s|gcr.io/kubebuilder/kube-rbac-proxy:.*$|${KUBE_RBAC_PROXY_IMAGE_PULLSPEC}|g" \
+       -e "s|quay.io/openshift/origin-kube-rbac-proxy:.*$|${KUBE_RBAC_PROXY_IMAGE_PULLSPEC}|g" "${CSV_FILE}"
 
 export EPOC_TIMESTAMP=$(date +%s)
 export TARGET_CSV_FILE="${CSV_FILE}"


### PR DESCRIPTION
In `container_digest.sh` it export the env as below
```
export KUBE_RBAC_PROXY_IMAGE_PULLSPEC='registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:56653df97e4498ecd67b9645d75e44f65c625594e312dbcf0f09937b57d76010'
```
when updating the CSV, should not add the extra `registry.redhat.io/openshift4/ose-kube-rbac-proxy:` before the pullspec.
