### PR TITLE
OCPBUGS-60009: Add AWS LB Controller CredentialsRequest in the e2e setup

### DIFF
--- a/hack/controller/README.md
+++ b/hack/controller/README.md
@@ -20,6 +20,6 @@ This `CrendetialsRequest` is a compact ("minified") version of the source IAM po
 This allows it to be created by both the Cloud Credential Operator and `ccoctl`.   
 Currently, this `CrendetialsRequest` is used in two places:
 - by the operator [to ensure `CredentialsRequest` CR](https://github.com/openshift/aws-load-balancer-operator/blob/a846cc27dc0f08adbf404714d308ded7f2cddebe/pkg/controllers/awsloadbalancercontroller/credentials_request.go#L145) during `AWSLoadBalancerController` reconciliation
-- by [the aws-load-balancer pre-install CI step](https://github.com/openshift/release/blob/d797eff6740de41ee2793866f358b246e2b52ae4/ci-operator/step-registry/aws-load-balancer/pre-install/aws-load-balancer-pre-install-commands.sh#L14) to create a secret for [some e2e test cases](https://github.com/openshift/aws-load-balancer-operator/blob/a846cc27dc0f08adbf404714d308ded7f2cddebe/test/e2e/operator_test.go#L324).
+- by the operator e2e tests to create a secret for [some e2e test cases](https://github.com/openshift/aws-load-balancer-operator/blob/a846cc27dc0f08adbf404714d308ded7f2cddebe/test/e2e/operator_test.go#L324).
 
 **Note**: this `CredentialsRequest` has broader permissions than the source IAM policy!

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -42,6 +42,7 @@ import (
 
 	albo "github.com/openshift/aws-load-balancer-operator/api/v1"
 	albov1alpha1 "github.com/openshift/aws-load-balancer-operator/api/v1alpha1"
+	"github.com/openshift/aws-load-balancer-operator/pkg/controllers/awsloadbalancercontroller"
 )
 
 const (
@@ -57,9 +58,6 @@ const (
 	wafWebACLIDVarName    = "ALBO_E2E_WAF_WEBACL_ID"
 	// controllerRoleARNVarName contains IAM role ARN to be used by the controller on a ROSA/STS cluster.
 	controllerRoleARNVarName = "ALBO_E2E_CONTROLLER_ROLE_ARN"
-
-	// controllerSecretName is the name of the controller's cloud credential secret provisioned by the CI.
-	controllerSecretName = "aws-load-balancer-controller-cluster"
 
 	// awsLoadBalancerControllerContainerName is the name of the AWS load balancer controller's container.
 	awsLoadBalancerControllerContainerName = "controller"
@@ -83,6 +81,10 @@ var (
 	httpClient    = http.Client{Timeout: 5 * time.Second}
 	e2eSecretName = types.NamespacedName{
 		Name:      "aws-load-balancer-operator-e2e",
+		Namespace: operatorNamespace,
+	}
+	controllerSecretName = types.NamespacedName{
+		Name:      "aws-load-balancer-controller-cluster",
 		Namespace: operatorNamespace,
 	}
 	controllerRoleARN string
@@ -132,6 +134,10 @@ func TestMain(m *testing.M) {
 	if !stsModeRequested() {
 		if err := ensureCredentialsRequest(e2eSecretName); err != nil {
 			fmt.Printf("failed to create credentialsrequest for e2e: %s\n", err)
+			os.Exit(1)
+		}
+		if err := ensureControllerCredentialsRequest(controllerSecretName); err != nil {
+			fmt.Printf("failed to create credentialsrequest for controller: %s\n", err)
 			os.Exit(1)
 		}
 		cfg, err = awsConfigWithCredentials(context.TODO(), kubeClient, infra.Status.PlatformStatus.AWS.Region, e2eSecretName)
@@ -256,7 +262,7 @@ func TestAWSLoadBalancerControllersV1Alpha1(t *testing.T) {
 
 	// The additional resource tags and the credentials secret are added to ALBC
 	// because they changed in v1.
-	alb := newALBCBuilder().withResourceTags(map[string]string{"testtag": "testval"}).withCredSecret(controllerSecretName).buildv1alpha1()
+	alb := newALBCBuilder().withResourceTags(map[string]string{"testtag": "testval"}).withCredSecret(controllerSecretName.Name).buildv1alpha1()
 	if err := kubeClient.Create(context.TODO(), alb); err != nil {
 		t.Fatalf("failed to create aws load balancer controller: %v", err)
 	}
@@ -334,7 +340,7 @@ func TestAWSLoadBalancerControllerWithCredentialsSecret(t *testing.T) {
 	}()
 
 	t.Log("Creating aws load balancer controller instance with credentials secret")
-	alb := newALBCBuilder().withCredSecret(controllerSecretName).build()
+	alb := newALBCBuilder().withCredSecret(controllerSecretName.Name).build()
 	if err := kubeClient.Create(context.TODO(), alb); err != nil {
 		t.Fatalf("failed to create aws load balancer controller: %v", err)
 	}
@@ -1415,6 +1421,38 @@ func ensureCredentialsRequest(secret types.NamespacedName) error {
 				Namespace: secret.Namespace,
 			},
 			ServiceAccountNames: []string{operatorName},
+			ProviderSpec:        providerSpec,
+		},
+	}
+
+	if err = kubeClient.Create(context.Background(), &cr); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+// ensureControllerCredentialsRequest creates CredentialsRequest to provision a secret with the cloud credentials
+// required by the controller in some of the e2e tests.
+func ensureControllerCredentialsRequest(secret types.NamespacedName) error {
+	providerSpec, err := cco.Codec.EncodeProviderSpec(&cco.AWSProviderSpec{
+		StatementEntries: awsloadbalancercontroller.GetIAMPolicyMinify().Statement,
+	})
+	if err != nil {
+		return err
+	}
+
+	cr := cco.CredentialsRequest{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "aws-load-balancer-controller",
+			Namespace: "openshift-cloud-credential-operator",
+		},
+		Spec: cco.CredentialsRequestSpec{
+			SecretRef: corev1.ObjectReference{
+				Name:      secret.Name,
+				Namespace: secret.Namespace,
+			},
+			ServiceAccountNames: []string{"aws-load-balancer-controller-cluster"},
 			ProviderSpec:        providerSpec,
 		},
 	}


### PR DESCRIPTION
AWS Load Balancer Controller CredentialsRequest is now created in the setup of the aws-load-balancer-operator e2e tests, eliminating the race condition where the target namespace for the request did not exist yet when the credentials request was created as part of the CI pre-install steps.

Example failure prior to this change:
> ```--- FAIL: TestAWSLoadBalancerControllerWithCredentialsSecret (920.10s) === RUN TestAWSLoadBalancerControllerWithCustomIngressClass operator_test.go:406: Creating test namespace "aws-load-balancer-test-custom-ing" operator_test.go:412: Creating a custom ingress class operator_test.go:422: Creating aws load balancer controller instance with custom ingress class util.go:72: failed to get deployment aws-load-balancer-controller-cluster: deployments.apps "aws-load-balancer-controller-cluster" not found (retrying) util.go:72: failed to get deployment aws-load-balancer-controller-cluster: deployments.apps "aws-load-balancer-controller-cluster" not found (retrying) util.go:72: failed to get deployment aws-load-balancer-controller-cluster: deployments.apps "aws-load-balancer-controller-cluster" not found (retrying) ```

Corresponding change in the CI steps: https://github.com/openshift/release/pull/69216