### PR TITLE
NO-JIRA: Add v1.3 tekton pipelines customizations

### DIFF
--- a/.tekton/aws-lb-bundle-container-aws-lb-optr-1-3-rhel-9-pull-request.yaml
+++ b/.tekton/aws-lb-bundle-container-aws-lb-optr-1-3-rhel-9-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && body.repository.full_name == "openshift/aws-load-balancer-operator"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: aws-lb-optr-1-3-rhel-9

--- a/.tekton/aws-lb-bundle-container-aws-lb-optr-1-3-rhel-9-push.yaml
+++ b/.tekton/aws-lb-bundle-container-aws-lb-optr-1-3-rhel-9-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && body.repository.full_name == "openshift/aws-load-balancer-operator"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: aws-lb-optr-1-3-rhel-9

--- a/.tekton/aws-load-balancer-operator-container-aws-lb-optr-1-3-rhel-9-pull-request.yaml
+++ b/.tekton/aws-load-balancer-operator-container-aws-lb-optr-1-3-rhel-9-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "main" && body.repository.full_name == "openshift/aws-load-balancer-operator"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: aws-lb-optr-1-3-rhel-9

--- a/.tekton/aws-load-balancer-operator-container-aws-lb-optr-1-3-rhel-9-push.yaml
+++ b/.tekton/aws-load-balancer-operator-container-aws-lb-optr-1-3-rhel-9-push.yaml
@@ -2,13 +2,14 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: bundle-hack/container_digest.sh
     build.appstudio.openshift.io/repo: https://github.com/openshift/aws-load-balancer-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "main" && body.repository.full_name == "openshift/aws-load-balancer-operator"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: aws-lb-optr-1-3-rhel-9


### PR DESCRIPTION
After creating new Konflux Components for ALBO v1.3, new tekton pipelines were created automatically using the default template. Our custom pipeline configurations need to be added back to the new pipelines.

List of customizations:
- Add bundle nudging configuration to the operator's on-push pipeline: https://github.com/openshift/aws-load-balancer-operator/pull/193/commits/f0d664489a16b62615e259b5b66cf10dfd3d0c4a
- Ensure tekton pipeline triggered only on source repository: https://github.com/openshift/aws-load-balancer-operator/pull/195/commits/4e57a7098d8621246884cf4cd47e355b65652b7f