### PR TITLE
NE-2123: Use latest tag for BUNDLE_IMG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ BUNDLE_TAG_BASE ?= quay.io/aws-load-balancer-operator/aws-load-balancer-operator
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= $(BUNDLE_TAG_BASE)-bundle:v$(BUNDLE_VERSION)
+BUNDLE_IMG ?= $(BUNDLE_TAG_BASE)-bundle:latest
 
 # IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for the operator image.
 IMAGE_TAG_BASE ?= openshift.io/aws-load-balancer-operator

--- a/catalog/aws-load-balancer-operator/bundle.yaml
+++ b/catalog/aws-load-balancer-operator/bundle.yaml
@@ -1,5 +1,5 @@
 ---
-image: quay.io/aws-load-balancer-operator/aws-load-balancer-operator-bundle:v1.2.0
+image: quay.io/aws-load-balancer-operator/aws-load-balancer-operator-bundle:latest
 name: aws-load-balancer-operator.v1.2.0
 package: aws-load-balancer-operator
 properties:
@@ -175,7 +175,7 @@ properties:
 relatedImages:
 - image: openshift.io/aws-load-balancer-operator:latest
   name: ""
-- image: quay.io/aws-load-balancer-operator/aws-load-balancer-operator-bundle:v1.2.0
+- image: quay.io/aws-load-balancer-operator/aws-load-balancer-operator-bundle:latest
   name: ""
 - image: quay.io/openshift/origin-kube-rbac-proxy:latest
   name: ""


### PR DESCRIPTION
Switch `BUNDLE_IMG` to use the floating `latest` tag. This decouples bundle image updates from FBC updates when introducing a new bundle version.

Previously, bumping the bundle version caused `make catalog` to fail, since it attempted to pull a new tag that wasn’t yet merged. With this change, `make catalog` continues using the previous `latest` bundle image until the version bump is merged and `latest` is updated with the new contents.