### PR TITLE
NE-2123: Update catalog to version 1.3.0

### DIFF
--- a/catalog/aws-load-balancer-operator/bundle.yaml
+++ b/catalog/aws-load-balancer-operator/bundle.yaml
@@ -1,6 +1,6 @@
 ---
 image: quay.io/aws-load-balancer-operator/aws-load-balancer-operator-bundle:latest
-name: aws-load-balancer-operator.v1.2.0
+name: aws-load-balancer-operator.v1.3.0
 package: aws-load-balancer-operator
 properties:
 - type: olm.gvk
@@ -31,7 +31,7 @@ properties:
 - type: olm.package
   value:
     packageName: aws-load-balancer-operator
-    version: 1.2.0
+    version: 1.3.0
 - type: olm.csv.metadata
   value:
     annotations:
@@ -106,7 +106,7 @@ properties:
       features.operators.openshift.io/token-auth-aws: "true"
       features.operators.openshift.io/token-auth-azure: "false"
       features.operators.openshift.io/token-auth-gcp: "false"
-      olm.skipRange: <1.2.0
+      olm.skipRange: <1.3.0
       operatorframework.io/suggested-namespace: aws-load-balancer-operator
       operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
       operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/catalog/aws-load-balancer-operator/channel.yaml
+++ b/catalog/aws-load-balancer-operator/channel.yaml
@@ -3,10 +3,10 @@ schema: olm.channel
 name: stable-v1
 package: aws-load-balancer-operator
 entries:
-  - name: aws-load-balancer-operator.v1.2.0
+  - name: aws-load-balancer-operator.v1.3.0
 ---
 schema: olm.channel
-name: stable-v1.2
+name: stable-v1.3
 package: aws-load-balancer-operator
 entries:
-  - name: aws-load-balancer-operator.v1.2.0
+  - name: aws-load-balancer-operator.v1.3.0


### PR DESCRIPTION
ALBO Bundle was updated to version 1.3.0 in https://github.com/openshift/aws-load-balancer-operator/commit/97c386b628beb1a7a9857fe5055536fda67cf948.

This commit regenerates the catalog with the latest ALBO v1.3.0 bundle.

Steps performed:
- Updated catalog/aws-load-balancer-operator/channel.yaml with new stable-v1.3 olm channel.
- Generated FBC with `make catalog`.