### PR TITLE
NE-2123: Fix typo in operator image pullspec

### DIFF
--- a/bundle-hack/container_digest.sh
+++ b/bundle-hack/container_digest.sh
@@ -1,6 +1,6 @@
 # Do not remove comment lines, they are there to reduce conflicts
 # Operator
-export OPERATOR_IMAGE_PULLSPEC='quay.io/redhat-user-workloads/aws-load-balancer-operator-tenant/aws-lb-optr-1-3-rhel-9/aws-load-balancer-operator-container-aws-lb-optr-1-3-rhel-9@sha256:sha256:sha256:e027254bc16920fba60402ce7ec24e0102cfedc64e633c087f8508f99e98fc7e'
+export OPERATOR_IMAGE_PULLSPEC='quay.io/redhat-user-workloads/aws-load-balancer-operator-tenant/aws-lb-optr-1-3-rhel-9/aws-load-balancer-operator-container-aws-lb-optr-1-3-rhel-9@sha256:e027254bc16920fba60402ce7ec24e0102cfedc64e633c087f8508f99e98fc7e'
 # Controller
 export OPERAND_IMAGE_PULLSPEC='quay.io/redhat-user-workloads/aws-load-balancer-operator-tenant/aws-lb-optr-1-3-rhel-9/aws-load-balancer-controller-container-aws-lb-optr-1-3-rhel-9@sha256:c4c54efa16a101b5b522ca960096f591976adc0b0b7082d5494a640f99967dd9'
 # kube-rbac-proxy


### PR DESCRIPTION
Fixing a typo introduced in https://github.com/openshift/aws-load-balancer-operator/pull/203.