### PR TITLE
NE-2401: Add support for AWS ISO partitions

### DIFF
--- a/api/v1/awsloadbalancercontroller_types.go
+++ b/api/v1/awsloadbalancercontroller_types.go
@@ -177,7 +177,7 @@ type AWSLoadBalancerCredentialsRequestConfig struct {
 	// This ARN is added to AWSProviderSpec initiating the creation of a secret containing IAM
 	// Role details necessary for assuming the IAM Role via Amazon's Secure Token Service (STS).
 	//
-	// +kubebuilder:validation:Pattern:=`^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role\/.*$`
+	// +kubebuilder:validation:Pattern:=`^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):iam::[0-9]{12}:role\/.*$`
 	// +kubebuilder:validation:Optional
 	// +optional
 	STSIAMRoleARN string `json:"stsIAMRoleARN,omitempty"`

--- a/assets/iam-policy.json
+++ b/assets/iam-policy.json
@@ -86,7 +86,7 @@
             "Action": [
                 "ec2:CreateTags"
             ],
-            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Resource": "arn:*:ec2:*:*:security-group/*",
             "Condition": {
                 "StringEquals": {
                     "ec2:CreateAction": "CreateSecurityGroup"
@@ -102,7 +102,7 @@
                 "ec2:CreateTags",
                 "ec2:DeleteTags"
             ],
-            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Resource": "arn:*:ec2:*:*:security-group/*",
             "Condition": {
                 "Null": {
                     "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
@@ -154,9 +154,9 @@
                 "elasticloadbalancing:RemoveTags"
             ],
             "Resource": [
-                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+                "arn:*:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:*:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:*:elasticloadbalancing:*:*:loadbalancer/app/*/*"
             ],
             "Condition": {
                 "Null": {
@@ -172,10 +172,10 @@
                 "elasticloadbalancing:RemoveTags"
             ],
             "Resource": [
-                "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
-                "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
-                "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
-                "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+                "arn:*:elasticloadbalancing:*:*:listener/net/*/*/*",
+                "arn:*:elasticloadbalancing:*:*:listener/app/*/*/*",
+                "arn:*:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+                "arn:*:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
             ]
         },
         {
@@ -184,9 +184,9 @@
                 "elasticloadbalancing:AddTags"
             ],
             "Resource": [
-                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+                "arn:*:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:*:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:*:elasticloadbalancing:*:*:loadbalancer/app/*/*"
             ],
             "Condition": {
                 "StringEquals": {
@@ -225,7 +225,7 @@
                 "elasticloadbalancing:RegisterTargets",
                 "elasticloadbalancing:DeregisterTargets"
             ],
-            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+            "Resource": "arn:*:elasticloadbalancing:*:*:targetgroup/*/*"
         },
         {
             "Effect": "Allow",

--- a/assets/operator-iam-policy.json
+++ b/assets/operator-iam-policy.json
@@ -14,7 +14,7 @@
         "ec2:DeleteTags"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:ec2:*:*:subnet/*"
+      "Resource": "arn:*:ec2:*:*:subnet/*"
     },
     {
       "Action": [

--- a/bundle/manifests/networking.olm.openshift.io_awsloadbalancercontrollers.yaml
+++ b/bundle/manifests/networking.olm.openshift.io_awsloadbalancercontrollers.yaml
@@ -138,7 +138,7 @@ spec:
                       which must be manually created for the controller's CredentialsRequest.
                       This ARN is added to AWSProviderSpec initiating the creation of a secret containing IAM
                       Role details necessary for assuming the IAM Role via Amazon's Secure Token Service (STS).
-                    pattern: ^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role\/.*$
+                    pattern: ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):iam::[0-9]{12}:role\/.*$
                     type: string
                 type: object
               enabledAddons:

--- a/config/crd/bases/networking.olm.openshift.io_awsloadbalancercontrollers.yaml
+++ b/config/crd/bases/networking.olm.openshift.io_awsloadbalancercontrollers.yaml
@@ -128,7 +128,7 @@ spec:
                       which must be manually created for the controller's CredentialsRequest.
                       This ARN is added to AWSProviderSpec initiating the creation of a secret containing IAM
                       Role details necessary for assuming the IAM Role via Amazon's Secure Token Service (STS).
-                    pattern: ^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role\/.*$
+                    pattern: ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):iam::[0-9]{12}:role\/.*$
                     type: string
                 type: object
               enabledAddons:

--- a/hack/controller/controller-credentials-request.yaml
+++ b/hack/controller/controller-credentials-request.yaml
@@ -74,7 +74,7 @@ spec:
     - action:
       - ec2:CreateTags
       effect: Allow
-      resource: "arn:aws:ec2:*:*:security-group/*"
+      resource: "arn:*:ec2:*:*:security-group/*"
       policyCondition:
           "Null":
               "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
@@ -84,7 +84,7 @@ spec:
       - ec2:CreateTags
       - ec2:DeleteTags
       effect: Allow
-      resource: "arn:aws:ec2:*:*:security-group/*"
+      resource: "arn:*:ec2:*:*:security-group/*"
       policyCondition:
           "Null":
               "aws:RequestTag/elbv2.k8s.aws/cluster": "true"
@@ -117,7 +117,7 @@ spec:
       - elasticloadbalancing:AddTags
       - elasticloadbalancing:RemoveTags
       effect: Allow
-      resource: "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+      resource: "arn:*:elasticloadbalancing:*:*:targetgroup/*/*"
       policyCondition:
           "Null":
               "aws:RequestTag/elbv2.k8s.aws/cluster": "true"
@@ -126,7 +126,7 @@ spec:
       - elasticloadbalancing:AddTags
       - elasticloadbalancing:RemoveTags
       effect: Allow
-      resource: "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*"
+      resource: "arn:*:elasticloadbalancing:*:*:loadbalancer/net/*/*"
       policyCondition:
           "Null":
               "aws:RequestTag/elbv2.k8s.aws/cluster": "true"
@@ -135,7 +135,7 @@ spec:
       - elasticloadbalancing:AddTags
       - elasticloadbalancing:RemoveTags
       effect: Allow
-      resource: "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+      resource: "arn:*:elasticloadbalancing:*:*:loadbalancer/app/*/*"
       policyCondition:
           "Null":
               "aws:RequestTag/elbv2.k8s.aws/cluster": "true"
@@ -144,26 +144,26 @@ spec:
       - elasticloadbalancing:AddTags
       - elasticloadbalancing:RemoveTags
       effect: Allow
-      resource: "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*"
+      resource: "arn:*:elasticloadbalancing:*:*:listener/net/*/*/*"
     - action:
       - elasticloadbalancing:AddTags
       - elasticloadbalancing:RemoveTags
       effect: Allow
-      resource: "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*"
+      resource: "arn:*:elasticloadbalancing:*:*:listener/app/*/*/*"
     - action:
       - elasticloadbalancing:AddTags
       - elasticloadbalancing:RemoveTags
       effect: Allow
-      resource: "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*"
+      resource: "arn:*:elasticloadbalancing:*:*:listener-rule/net/*/*/*"
     - action:
       - elasticloadbalancing:AddTags
       - elasticloadbalancing:RemoveTags
       effect: Allow
-      resource: "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+      resource: "arn:*:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
     - action:
       - elasticloadbalancing:AddTags
       effect: Allow
-      resource: "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+      resource: "arn:*:elasticloadbalancing:*:*:targetgroup/*/*"
       policyCondition:
           "Null":
               "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
@@ -172,7 +172,7 @@ spec:
     - action:
       - elasticloadbalancing:AddTags
       effect: Allow
-      resource: "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*"
+      resource: "arn:*:elasticloadbalancing:*:*:loadbalancer/net/*/*"
       policyCondition:
           "Null":
               "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
@@ -181,7 +181,7 @@ spec:
     - action:
       - elasticloadbalancing:AddTags
       effect: Allow
-      resource: "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+      resource: "arn:*:elasticloadbalancing:*:*:loadbalancer/app/*/*"
       policyCondition:
           "Null":
               "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
@@ -205,7 +205,7 @@ spec:
       - elasticloadbalancing:RegisterTargets
       - elasticloadbalancing:DeregisterTargets
       effect: Allow
-      resource: "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+      resource: "arn:*:elasticloadbalancing:*:*:targetgroup/*/*"
     - action:
       - elasticloadbalancing:SetWebAcl
       - elasticloadbalancing:ModifyListener

--- a/hack/operator-credentials-request.yaml
+++ b/hack/operator-credentials-request.yaml
@@ -16,7 +16,7 @@ spec:
           - ec2:CreateTags
           - ec2:DeleteTags
         effect: Allow
-        resource: arn:aws:ec2:*:*:subnet/*
+        resource: arn:*:ec2:*:*:subnet/*
       - action:
           - ec2:DescribeVpcs
         effect: Allow

--- a/hack/operator-permission-policy.json
+++ b/hack/operator-permission-policy.json
@@ -14,7 +14,7 @@
         "ec2:DeleteTags"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:ec2:*:*:subnet/*"
+      "Resource": "arn:*:ec2:*:*:subnet/*"
     },
     {
       "Action": [

--- a/pkg/controllers/awsloadbalancercontroller/iam_policy.go
+++ b/pkg/controllers/awsloadbalancercontroller/iam_policy.go
@@ -96,7 +96,7 @@ func GetIAMPolicy() IAMPolicy {
 			},
 			{
 				Effect:   "Allow",
-				Resource: "arn:aws:ec2:*:*:security-group/*",
+				Resource: "arn:*:ec2:*:*:security-group/*",
 				PolicyCondition: cco.IAMPolicyCondition{
 					"Null": cco.IAMPolicyConditionKeyValue{
 						"aws:RequestTag/elbv2.k8s.aws/cluster": "false",
@@ -111,7 +111,7 @@ func GetIAMPolicy() IAMPolicy {
 			},
 			{
 				Effect:   "Allow",
-				Resource: "arn:aws:ec2:*:*:security-group/*",
+				Resource: "arn:*:ec2:*:*:security-group/*",
 				PolicyCondition: cco.IAMPolicyCondition{
 					"Null": cco.IAMPolicyConditionKeyValue{
 						"aws:RequestTag/elbv2.k8s.aws/cluster":  "true",
@@ -163,7 +163,7 @@ func GetIAMPolicy() IAMPolicy {
 			},
 			{
 				Effect:   "Allow",
-				Resource: "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+				Resource: "arn:*:elasticloadbalancing:*:*:targetgroup/*/*",
 				PolicyCondition: cco.IAMPolicyCondition{
 					"Null": cco.IAMPolicyConditionKeyValue{
 						"aws:RequestTag/elbv2.k8s.aws/cluster":  "true",
@@ -177,7 +177,7 @@ func GetIAMPolicy() IAMPolicy {
 			},
 			{
 				Effect:   "Allow",
-				Resource: "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+				Resource: "arn:*:elasticloadbalancing:*:*:loadbalancer/net/*/*",
 				PolicyCondition: cco.IAMPolicyCondition{
 					"Null": cco.IAMPolicyConditionKeyValue{
 						"aws:RequestTag/elbv2.k8s.aws/cluster":  "true",
@@ -191,7 +191,7 @@ func GetIAMPolicy() IAMPolicy {
 			},
 			{
 				Effect:   "Allow",
-				Resource: "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*",
+				Resource: "arn:*:elasticloadbalancing:*:*:loadbalancer/app/*/*",
 				PolicyCondition: cco.IAMPolicyCondition{
 					"Null": cco.IAMPolicyConditionKeyValue{
 						"aws:RequestTag/elbv2.k8s.aws/cluster":  "true",
@@ -205,7 +205,7 @@ func GetIAMPolicy() IAMPolicy {
 			},
 			{
 				Effect:          "Allow",
-				Resource:        "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+				Resource:        "arn:*:elasticloadbalancing:*:*:listener/net/*/*/*",
 				PolicyCondition: cco.IAMPolicyCondition{},
 				Action: []string{
 					"elasticloadbalancing:AddTags",
@@ -214,7 +214,7 @@ func GetIAMPolicy() IAMPolicy {
 			},
 			{
 				Effect:          "Allow",
-				Resource:        "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+				Resource:        "arn:*:elasticloadbalancing:*:*:listener/app/*/*/*",
 				PolicyCondition: cco.IAMPolicyCondition{},
 				Action: []string{
 					"elasticloadbalancing:AddTags",
@@ -223,7 +223,7 @@ func GetIAMPolicy() IAMPolicy {
 			},
 			{
 				Effect:          "Allow",
-				Resource:        "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+				Resource:        "arn:*:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
 				PolicyCondition: cco.IAMPolicyCondition{},
 				Action: []string{
 					"elasticloadbalancing:AddTags",
@@ -232,7 +232,7 @@ func GetIAMPolicy() IAMPolicy {
 			},
 			{
 				Effect:          "Allow",
-				Resource:        "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*",
+				Resource:        "arn:*:elasticloadbalancing:*:*:listener-rule/app/*/*/*",
 				PolicyCondition: cco.IAMPolicyCondition{},
 				Action: []string{
 					"elasticloadbalancing:AddTags",
@@ -241,7 +241,7 @@ func GetIAMPolicy() IAMPolicy {
 			},
 			{
 				Effect:   "Allow",
-				Resource: "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+				Resource: "arn:*:elasticloadbalancing:*:*:targetgroup/*/*",
 				PolicyCondition: cco.IAMPolicyCondition{
 					"Null": cco.IAMPolicyConditionKeyValue{
 						"aws:RequestTag/elbv2.k8s.aws/cluster": "false",
@@ -256,7 +256,7 @@ func GetIAMPolicy() IAMPolicy {
 			},
 			{
 				Effect:   "Allow",
-				Resource: "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+				Resource: "arn:*:elasticloadbalancing:*:*:loadbalancer/net/*/*",
 				PolicyCondition: cco.IAMPolicyCondition{
 					"Null": cco.IAMPolicyConditionKeyValue{
 						"aws:RequestTag/elbv2.k8s.aws/cluster": "false",
@@ -271,7 +271,7 @@ func GetIAMPolicy() IAMPolicy {
 			},
 			{
 				Effect:   "Allow",
-				Resource: "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*",
+				Resource: "arn:*:elasticloadbalancing:*:*:loadbalancer/app/*/*",
 				PolicyCondition: cco.IAMPolicyCondition{
 					"Null": cco.IAMPolicyConditionKeyValue{
 						"aws:RequestTag/elbv2.k8s.aws/cluster": "false",
@@ -305,7 +305,7 @@ func GetIAMPolicy() IAMPolicy {
 			},
 			{
 				Effect:          "Allow",
-				Resource:        "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+				Resource:        "arn:*:elasticloadbalancing:*:*:targetgroup/*/*",
 				PolicyCondition: cco.IAMPolicyCondition{},
 				Action: []string{
 					"elasticloadbalancing:RegisterTargets",

--- a/pkg/operator/credentials_test.go
+++ b/pkg/operator/credentials_test.go
@@ -68,6 +68,36 @@ func Test_ProvisionCredentials(t *testing.T) {
 			expectedContents: "oksts",
 		},
 		{
+			name: "nominal sts iso partition",
+			envVars: map[string]string{
+				"ROLEARN": "arn:aws-iso:iam::123456789012:role/foo",
+			},
+			scheme: test.Scheme,
+			provisionedSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "aws-load-balancer-operator",
+					Namespace: "aws-load-balancer-operator",
+				},
+				Data: map[string][]byte{
+					"credentials": []byte("okiso"),
+				},
+			},
+			expectedCredReqName: types.NamespacedName{
+				Namespace: "openshift-cloud-credential-operator",
+				Name:      "aws-load-balancer-operator",
+			},
+			compareCredReq: func(credReq *cco.CredentialsRequest, providerSpec *cco.AWSProviderSpec) error {
+				if providerSpec.STSIAMRoleARN != "arn:aws-iso:iam::123456789012:role/foo" {
+					return fmt.Errorf("got unexpected role arn: %q", providerSpec.STSIAMRoleARN)
+				}
+				if credReq.Spec.CloudTokenPath != "/var/run/secrets/openshift/serviceaccount/token" {
+					return fmt.Errorf("got unexpected token path: %q", credReq.Spec.CloudTokenPath)
+				}
+				return nil
+			},
+			expectedContents: "okiso",
+		},
+		{
 			name:   "nominal non sts",
 			scheme: test.Scheme,
 			provisionedSecret: &corev1.Secret{

--- a/pkg/operator/iam_policy.go
+++ b/pkg/operator/iam_policy.go
@@ -20,7 +20,7 @@ func GetIAMPolicy() IAMPolicy {
 			},
 			{
 				Effect:          "Allow",
-				Resource:        "arn:aws:ec2:*:*:subnet/*",
+				Resource:        "arn:*:ec2:*:*:subnet/*",
 				PolicyCondition: cco.IAMPolicyCondition{},
 				Action: []string{
 					"ec2:CreateTags",

--- a/pkg/utils/resource/update/credentials_request_test.go
+++ b/pkg/utils/resource/update/credentials_request_test.go
@@ -122,7 +122,7 @@ func Test_CredentialsRequest(t *testing.T) {
 				StatementEntries: []cco.StatementEntry{
 					{
 						Effect:          "Allow",
-						Resource:        "arn:aws:ec2:*:*:subnet/*",
+						Resource:        "arn:*:ec2:*:*:subnet/*",
 						PolicyCondition: cco.IAMPolicyCondition{},
 						Action: []string{
 							"ec2:DescribeSubnets",


### PR DESCRIPTION
Update IAM policy resource ARNs from `arn:aws:` to `arn:*:` to support all AWS partitions. Extend the `stsIAMRoleARN` CRD validation regex to accept `aws-iso`, `aws-iso-b`, `aws-iso-e`, and `aws-iso-f` partitions in addition to the existing `aws`, `aws-cn`, and `aws-us-gov`.

The CRD validation serves as the enforcement point for which partitions are supported, while `arn:*:` in the IAM policy resources ensures permissions work in whichever partition the cluster runs in. Note that the minified IAM policy used in non-STS clusters already collapses all resources to `*`, so the partition-specific ARNs only matter for the non-minified STS policy.