### PR TITLE
NO-JIRA: Fix placeholder URL and typo in OLM catalog/bundle

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -459,7 +459,7 @@ spec:
   - ingress
   links:
   - name: Aws Load Balancer Operator
-    url: https://aws-load-balancer-operator.domain
+    url: https://github.com/openshift/aws-load-balancer-operator
   maturity: alpha
   minKubeVersion: 1.20.0
   provider:

--- a/catalog/v4.17/catalog.yaml
+++ b/catalog/v4.17/catalog.yaml
@@ -235,7 +235,7 @@ properties:
       oc get secret -n aws-load-balancer-operator aws-load-balancer-operator
       ```
 
-      After this the operator can be installated through the console or through the command line.
+      After this the operator can be installed through the console or through the command line.
 
       __Note about UPI:__ For UPI based installs, additional documentation can be found in
       [VPC and subnets](https://github.com/openshift/aws-load-balancer-operator/blob/main/docs/prerequisites.md#vpc-and-subnets)
@@ -258,7 +258,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -466,7 +466,7 @@ properties:
       oc get secret -n aws-load-balancer-operator aws-load-balancer-operator
       ```
 
-      After this the operator can be installated through the console or through the command line.
+      After this the operator can be installed through the console or through the command line.
 
       __Note about UPI:__ For UPI based installs, additional documentation can be found in
       [VPC and subnets](https://github.com/openshift/aws-load-balancer-operator/blob/release-1.0/docs/prerequisites.md#vpc-and-subnets)
@@ -489,7 +489,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -671,7 +671,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -859,7 +859,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -1047,7 +1047,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:

--- a/catalog/v4.18/catalog.yaml
+++ b/catalog/v4.18/catalog.yaml
@@ -235,7 +235,7 @@ properties:
       oc get secret -n aws-load-balancer-operator aws-load-balancer-operator
       ```
 
-      After this the operator can be installated through the console or through the command line.
+      After this the operator can be installed through the console or through the command line.
 
       __Note about UPI:__ For UPI based installs, additional documentation can be found in
       [VPC and subnets](https://github.com/openshift/aws-load-balancer-operator/blob/main/docs/prerequisites.md#vpc-and-subnets)
@@ -258,7 +258,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -466,7 +466,7 @@ properties:
       oc get secret -n aws-load-balancer-operator aws-load-balancer-operator
       ```
 
-      After this the operator can be installated through the console or through the command line.
+      After this the operator can be installed through the console or through the command line.
 
       __Note about UPI:__ For UPI based installs, additional documentation can be found in
       [VPC and subnets](https://github.com/openshift/aws-load-balancer-operator/blob/release-1.0/docs/prerequisites.md#vpc-and-subnets)
@@ -489,7 +489,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -671,7 +671,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -859,7 +859,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -1047,7 +1047,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:

--- a/catalog/v4.19/catalog.yaml
+++ b/catalog/v4.19/catalog.yaml
@@ -245,7 +245,7 @@ properties:
       oc get secret -n aws-load-balancer-operator aws-load-balancer-operator
       ```
 
-      After this the operator can be installated through the console or through the command line.
+      After this the operator can be installed through the console or through the command line.
 
       __Note about UPI:__ For UPI based installs, additional documentation can be found in
       [VPC and subnets](https://github.com/openshift/aws-load-balancer-operator/blob/main/docs/prerequisites.md#vpc-and-subnets)
@@ -268,7 +268,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -476,7 +476,7 @@ properties:
       oc get secret -n aws-load-balancer-operator aws-load-balancer-operator
       ```
 
-      After this the operator can be installated through the console or through the command line.
+      After this the operator can be installed through the console or through the command line.
 
       __Note about UPI:__ For UPI based installs, additional documentation can be found in
       [VPC and subnets](https://github.com/openshift/aws-load-balancer-operator/blob/release-1.0/docs/prerequisites.md#vpc-and-subnets)
@@ -499,7 +499,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -681,7 +681,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -869,7 +869,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -1057,7 +1057,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -1247,7 +1247,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:

--- a/catalog/v4.20/catalog.yaml
+++ b/catalog/v4.20/catalog.yaml
@@ -245,7 +245,7 @@ properties:
       oc get secret -n aws-load-balancer-operator aws-load-balancer-operator
       ```
 
-      After this the operator can be installated through the console or through the command line.
+      After this the operator can be installed through the console or through the command line.
 
       __Note about UPI:__ For UPI based installs, additional documentation can be found in
       [VPC and subnets](https://github.com/openshift/aws-load-balancer-operator/blob/main/docs/prerequisites.md#vpc-and-subnets)
@@ -268,7 +268,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -476,7 +476,7 @@ properties:
       oc get secret -n aws-load-balancer-operator aws-load-balancer-operator
       ```
 
-      After this the operator can be installated through the console or through the command line.
+      After this the operator can be installed through the console or through the command line.
 
       __Note about UPI:__ For UPI based installs, additional documentation can be found in
       [VPC and subnets](https://github.com/openshift/aws-load-balancer-operator/blob/release-1.0/docs/prerequisites.md#vpc-and-subnets)
@@ -499,7 +499,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -681,7 +681,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -869,7 +869,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -1057,7 +1057,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -1247,7 +1247,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:

--- a/catalog/v4.21/catalog.yaml
+++ b/catalog/v4.21/catalog.yaml
@@ -245,7 +245,7 @@ properties:
       oc get secret -n aws-load-balancer-operator aws-load-balancer-operator
       ```
 
-      After this the operator can be installated through the console or through the command line.
+      After this the operator can be installed through the console or through the command line.
 
       __Note about UPI:__ For UPI based installs, additional documentation can be found in
       [VPC and subnets](https://github.com/openshift/aws-load-balancer-operator/blob/main/docs/prerequisites.md#vpc-and-subnets)
@@ -268,7 +268,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -476,7 +476,7 @@ properties:
       oc get secret -n aws-load-balancer-operator aws-load-balancer-operator
       ```
 
-      After this the operator can be installated through the console or through the command line.
+      After this the operator can be installed through the console or through the command line.
 
       __Note about UPI:__ For UPI based installs, additional documentation can be found in
       [VPC and subnets](https://github.com/openshift/aws-load-balancer-operator/blob/release-1.0/docs/prerequisites.md#vpc-and-subnets)
@@ -499,7 +499,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -681,7 +681,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -869,7 +869,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -1057,7 +1057,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -1247,7 +1247,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:

--- a/catalog/v4.22/catalog.yaml
+++ b/catalog/v4.22/catalog.yaml
@@ -245,7 +245,7 @@ properties:
       oc get secret -n aws-load-balancer-operator aws-load-balancer-operator
       ```
 
-      After this the operator can be installated through the console or through the command line.
+      After this the operator can be installed through the console or through the command line.
 
       __Note about UPI:__ For UPI based installs, additional documentation can be found in
       [VPC and subnets](https://github.com/openshift/aws-load-balancer-operator/blob/main/docs/prerequisites.md#vpc-and-subnets)
@@ -268,7 +268,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -476,7 +476,7 @@ properties:
       oc get secret -n aws-load-balancer-operator aws-load-balancer-operator
       ```
 
-      After this the operator can be installated through the console or through the command line.
+      After this the operator can be installed through the console or through the command line.
 
       __Note about UPI:__ For UPI based installs, additional documentation can be found in
       [VPC and subnets](https://github.com/openshift/aws-load-balancer-operator/blob/release-1.0/docs/prerequisites.md#vpc-and-subnets)
@@ -499,7 +499,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -681,7 +681,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -869,7 +869,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -1057,7 +1057,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:
@@ -1247,7 +1247,7 @@ properties:
     - ingress
     links:
     - name: Aws Load Balancer Operator
-      url: https://aws-load-balancer-operator.domain
+      url: https://github.com/openshift/aws-load-balancer-operator
     maturity: alpha
     minKubeVersion: 1.20.0
     provider:

--- a/config/manifests/bases/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -72,7 +72,7 @@ spec:
   - ingress
   links:
   - name: Aws Load Balancer Operator
-    url: https://aws-load-balancer-operator.domain
+    url: https://github.com/openshift/aws-load-balancer-operator
   maturity: alpha
   minKubeVersion: 1.20.0
   provider:


### PR DESCRIPTION
- Replace placeholder `https://aws-load-balancer-operator.domain` URL with `https://github.com/openshift/aws-load-balancer-operator` across CSV and catalog files.
- Fix `installated` → `installed` typo in catalog descriptions.