### PR TITLE
NE-2756: Bump kube-rbac-proxy to v4.19

### DIFF
--- a/bundle-hack/container_digest.sh
+++ b/bundle-hack/container_digest.sh
@@ -4,6 +4,6 @@ export OPERATOR_IMAGE_PULLSPEC='registry.redhat.io/albo/aws-load-balancer-rhel9-
 # Controller
 export OPERAND_IMAGE_PULLSPEC='registry.redhat.io/albo/aws-load-balancer-controller-rhel9@sha256:9e8c70085842ff1c3404075a2b99deeeeaa8c35e257b997bb7fe58cf8a0a15aa'
 # kube-rbac-proxy
-# Latest version of v4.14 tag is used.
-# Catalog link (health grade A): https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy/5cdb2634dd19c778293b4d98?image=691eb72e6d4c48dbffa76548
-export KUBE_RBAC_PROXY_IMAGE_PULLSPEC='registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:ba9ff4c933739f1774bc8277d636053c5306863221a8c7b7b9ddc4470eb7feff'
+# Latest version of v4.19 tag is used.
+# Catalog link (health grade A): https://catalog.redhat.com/en/software/containers/openshift4/ose-kube-rbac-proxy-rhel9/652809a5244cb343fb4a4b66?image=6a291e91c7ee40ca259b3f3a
+export KUBE_RBAC_PROXY_IMAGE_PULLSPEC='registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:32540431240e12c07d35f9f390b196aae5cc2188e9db6365e41e6bbe7070d8c2'


### PR DESCRIPTION
## Summary

- Update `KUBE_RBAC_PROXY_IMAGE_PULLSPEC` in `bundle-hack/container_digest.sh` to the latest v4.19 image (`ose-kube-rbac-proxy-rhel9`) which currently has a health index grade A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)