### PR TITLE
NE-2756: Add Konflux labels to operator and bundle Containerfiles

### DIFF
--- a/Containerfile.aws-load-balancer-operator
+++ b/Containerfile.aws-load-balancer-operator
@@ -33,7 +33,7 @@ ARG GIT_URL
 
 LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="aws-load-balancer-operator-container"
-LABEL name="aws-load-balancer-operator"
+LABEL name="albo/aws-load-balancer-operator"
 LABEL version="1.3.1"
 LABEL cpe="cpe:/a:redhat:aws_lb_optr:1.3::el9"
 LABEL io.openshift.build.commit.id=${FULL_COMMIT}

--- a/Containerfile.aws-load-balancer-operator
+++ b/Containerfile.aws-load-balancer-operator
@@ -35,6 +35,7 @@ LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="aws-load-balancer-operator-container"
 LABEL name="aws-load-balancer-operator"
 LABEL version="1.3.1"
+LABEL cpe="cpe:/a:redhat:aws_lb_optr:1.3::el9"
 LABEL io.openshift.build.commit.id=${FULL_COMMIT}
 LABEL io.openshift.build.source-location=${GIT_URL}
 LABEL io.openshift.build.commit.url=${GIT_URL}/commit/${FULL_COMMIT}

--- a/Containerfile.aws-load-balancer-operator-bundle
+++ b/Containerfile.aws-load-balancer-operator-bundle
@@ -55,6 +55,7 @@ LABEL io.k8s.display-name='AWS Load Balancer Operator'
 LABEL io.k8s.description='Operator bundle for the AWS Load Balancer Operator'
 LABEL io.openshift.tags='networking,ingress'
 LABEL com.redhat.component='aws-load-balancer-operator-bundle-container'
+LABEL cpe="cpe:/a:redhat:aws_lb_optr:1.3::el9"
 LABEL com.redhat.license_terms='https://www.redhat.com/agreements'
 LABEL description='Operator bundle for the AWS Load Balancer Operator'
 LABEL io.openshift.build.commit.id=${FULL_COMMIT}

--- a/Containerfile.aws-load-balancer-operator-bundle
+++ b/Containerfile.aws-load-balancer-operator-bundle
@@ -47,7 +47,7 @@ LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 LABEL com.redhat.delivery.backport: false
 # this is a bundle image and should be delivered via an index image
 LABEL com.redhat.delivery.operator.bundle: true
-LABEL name=aws-load-balancer-operator-bundle
+LABEL name="albo/aws-load-balancer-operator-bundle"
 LABEL version="1.3.1"
 LABEL release="1.3.1"
 LABEL maintainer='NetworkEdge team <aos-network-edge-staff@redhat.com>'


### PR DESCRIPTION
## Summary

- Add `cpe` label to operator and bundle Containerfiles (`cpe:/a:redhat:aws_lb_optr:1.3::el9`).
- Add `albo/` prefix to the `name` label in Containerfiles to pass the Konflux `check-labels` task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)