### PR TITLE
NE-2754: Declare NetworkPolicy RBAC for awsloadbalancercontroller

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -429,6 +429,18 @@ spec:
           - update
           - watch
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - rolebindings

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -140,6 +140,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/pkg/controllers/awsloadbalancercontroller/controller.go
+++ b/pkg/controllers/awsloadbalancercontroller/controller.go
@@ -80,6 +80,7 @@ type AWSLoadBalancerControllerReconciler struct {
 //+kubebuilder:rbac:groups="networking.k8s.io",resources=ingressclasses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="config.openshift.io",resources=infrastructures,verbs=get;list;watch
 //+kubebuilder:rbac:groups="apps",resources=deployments,namespace=system,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="networking.k8s.io",resources=networkpolicies,namespace=system,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,namespace=system,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,namespace=system,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
To ensure OCP 5.0 compliance AWS Load Balancer Operator must comply with the Conforma policy `olm.required_network_policy_rbac_for_operands`.

This policy ensures operator bundles declare sufficient RBAC permissions to manage NetworkPolicies on behalf of their operands.

Steps:
- Add the kubebuilder RBAC marker in the awsloadbalancercontroller
- Regenerate operator bundle with `make bundle` which updates the `config/rbac/role.yaml` and the operator CSV file.