### PR TITLE
NE-2840: Enable ServiceMonitor for Prometheus metrics scraping

### DIFF
--- a/bundle/manifests/aws-load-balancer-operator-cabundle_v1_configmap.yaml
+++ b/bundle/manifests/aws-load-balancer-operator-cabundle_v1_configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: aws-load-balancer-operator-cabundle

--- a/bundle/manifests/aws-load-balancer-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/aws-load-balancer-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: aws-load-balancer-operator-controller-manager-metrics-monitor
+spec:
+  endpoints:
+  - authorization:
+      credentials:
+        key: token
+        name: aws-load-balancer-operator-metrics-scraper-token
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      ca:
+        configMap:
+          key: service-ca.crt
+          name: aws-load-balancer-operator-cabundle
+      serverName: aws-load-balancer-operator-controller-manager-metrics-service.aws-load-balancer-operator.svc
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/bundle/manifests/aws-load-balancer-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/aws-load-balancer-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: aws-load-balancer-operator-metrics-tls
   creationTimestamp: null
   labels:
     control-plane: controller-manager

--- a/bundle/manifests/aws-load-balancer-operator-metrics-scraper-token_v1_secret.yaml
+++ b/bundle/manifests/aws-load-balancer-operator-metrics-scraper-token_v1_secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: aws-load-balancer-operator-metrics-scraper
+  name: aws-load-balancer-operator-metrics-scraper-token
+type: kubernetes.io/service-account-token

--- a/bundle/manifests/aws-load-balancer-operator-metrics-scraper_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/aws-load-balancer-operator-metrics-scraper_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: aws-load-balancer-operator-metrics-scraper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-load-balancer-operator-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: aws-load-balancer-operator-metrics-scraper
+  namespace: aws-load-balancer-operator

--- a/bundle/manifests/aws-load-balancer-operator-metrics-scraper_v1_serviceaccount.yaml
+++ b/bundle/manifests/aws-load-balancer-operator-metrics-scraper_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: aws-load-balancer-operator-metrics-scraper

--- a/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/aws-load-balancer-operator.clusterserviceversion.yaml
@@ -258,6 +258,7 @@ spec:
                 - --image=$(RELATED_IMAGE_CONTROLLER)
                 - --namespace=$(TARGET_NAMESPACE)
                 - --trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)
+                - --metrics-tls-cert-dir=/var/run/secrets/serving-cert
                 - --webhook-disable-http2
                 command:
                 - /manager
@@ -318,6 +319,9 @@ spec:
                 - mountPath: /etc/pki/tls/certs/albo-tls-ca-bundle.crt
                   name: trusted-cabundle
                   subPath: ca-bundle.crt
+                - mountPath: /var/run/secrets/serving-cert
+                  name: metrics-cert
+                  readOnly: true
               securityContext:
                 runAsNonRoot: true
                 seccompProfile:
@@ -337,6 +341,10 @@ spec:
                   defaultMode: 420
                   name: aws-load-balancer-operator-trusted-cabundle
                 name: trusted-cabundle
+              - name: metrics-cert
+                secret:
+                  defaultMode: 420
+                  secretName: aws-load-balancer-operator-metrics-tls
       permissions:
       - rules:
         - apiGroups:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -22,7 +22,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 
 patchesStrategicMerge:
 # Mount the controller config file for loading manager configurations

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,6 +12,10 @@ configMapGenerator:
   options:
     labels:
       config.openshift.io/inject-trusted-cabundle: "true"
+- name: cabundle
+  options:
+    annotations:
+      service.beta.openshift.io/inject-cabundle: "true"
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -37,6 +37,7 @@ spec:
         - "--image=$(RELATED_IMAGE_CONTROLLER)"
         - "--namespace=$(TARGET_NAMESPACE)"
         - "--trusted-ca-configmap=$(TRUSTED_CA_CONFIGMAP_NAME)"
+        - "--metrics-tls-cert-dir=/var/run/secrets/serving-cert"
         - "--webhook-disable-http2"
         image: controller:latest
         name: manager
@@ -97,6 +98,9 @@ spec:
           - mountPath: /etc/pki/tls/certs/albo-tls-ca-bundle.crt
             name: trusted-cabundle
             subPath: ca-bundle.crt
+          - mountPath: /var/run/secrets/serving-cert
+            name: metrics-cert
+            readOnly: true
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       volumes:
@@ -112,3 +116,7 @@ spec:
           configMap:
             defaultMode: 420
             name: aws-load-balancer-operator-trusted-cabundle
+        - name: metrics-cert
+          secret:
+            defaultMode: 420
+            secretName: aws-load-balancer-operator-metrics-tls

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -12,9 +12,16 @@ spec:
     - path: /metrics
       port: https
       scheme: https
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      authorization:
+        credentials:
+          key: token
+          name: aws-load-balancer-operator-metrics-scraper-token
       tlsConfig:
-        insecureSkipVerify: true
+        ca:
+          configMap:
+            key: service-ca.crt
+            name: aws-load-balancer-operator-cabundle
+        serverName: aws-load-balancer-operator-controller-manager-metrics-service.aws-load-balancer-operator.svc
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: aws-load-balancer-operator-metrics-tls
   name: controller-manager-metrics-service
   namespace: system
 spec:

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -17,3 +17,6 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+- metrics_scraper_service_account.yaml
+- metrics_scraper_secret.yaml
+- metrics_scraper_clusterrolebinding.yaml

--- a/config/rbac/metrics_scraper_clusterrolebinding.yaml
+++ b/config/rbac/metrics_scraper_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-scraper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-scraper
+  namespace: system

--- a/config/rbac/metrics_scraper_secret.yaml
+++ b/config/rbac/metrics_scraper_secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metrics-scraper-token
+  namespace: system
+  annotations:
+    kubernetes.io/service-account.name: aws-load-balancer-operator-metrics-scraper
+type: kubernetes.io/service-account-token

--- a/config/rbac/metrics_scraper_service_account.yaml
+++ b/config/rbac/metrics_scraper_service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-scraper
+  namespace: system

--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ func init() {
 func main() {
 	var (
 		metricsAddr            string
+		metricsTLSCertDir      string
 		enableLeaderElection   bool
 		probeAddr              string
 		namespace              string
@@ -98,6 +99,7 @@ func main() {
 		webhookDisableHTTP2    bool
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8443", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsTLSCertDir, "metrics-tls-cert-dir", "", "The directory containing TLS certificates for the metrics endpoint.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
@@ -138,6 +140,7 @@ func main() {
 		Metrics: metrics.Options{
 			BindAddress:    metricsAddr,
 			SecureServing:  true,
+			CertDir:        metricsTLSCertDir,
 			FilterProvider: filters.WithAuthenticationAndAuthorization,
 			TLSOpts: []func(*tls.Config){
 				func(config *tls.Config) {


### PR DESCRIPTION
## Summary

- Enable the `ServiceMonitor` resource that was scaffolded but never activated, so the in-cluster Prometheus stack can discover and scrape the operator's `/metrics` endpoint.
- Use **user workload monitoring** instead of platform cluster monitoring. Unlike the [External DNS Operator approach](https://github.com/openshift/external-dns-operator/pull/156) which labels the namespace with `openshift.io/cluster-monitoring=true` to route metrics through the platform Prometheus, ALBO relies on the [user workload monitoring stack](https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.22/html/configuring_user_workload_monitoring/configuring-metrics-uwm#example-service-endpoint-authentication-settings_configuring-metrics-uwm).
- The user workload Prometheus enforces `arbitraryFSAccessThroughSMs: deny`, which prohibits filesystem path references in ServiceMonitors (both `bearerTokenFile` and `tlsConfig.caFile`). To comply, a `metrics-scraper` ServiceAccount with a bound token Secret and a ClusterRoleBinding to the `metrics-reader` ClusterRole is added. The ServiceMonitor references this Secret via `authorization.credentials`.

**Prerequisite**: user workload monitoring must be [enabled](https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.22/html/configuring_user_workload_monitoring/preparing-to-configure-the-monitoring-stack-uwm) on the cluster (`enableUserWorkload: true` in `oc -n openshift-monitoring get configmap cluster-monitoring-config`).

Follow-up to #313 as discussed in https://github.com/openshift/aws-load-balancer-operator/pull/313#pullrequestreview-4862696554.

**Scraping flow**
- User workload Prometheus stack establishes a TLS connection with ALBO metrics server (ALBO sends metrics service's serving TLS certificate which Prometheus verifies using CA bundle configmap from `ServiceMonitor`)
- User workload Prometheus stack  sends a scrape request against `/metrics` endpoint of ALBO metrics service (request contains token from `ServiceMonitor`)
- ALBO controller-runtime's `FilterProvider` verifies the token is a valid one (`TokenReview`)
- ALBO controller-runtime's `FilterProvider` checks that the SA associated to the token has rights to scrape (`SubjectAccessReview`, `aws-load-balancer-operator-metrics-reader` clusterrole must be granted to the SA)
- ALBO controller-runtime's metrics server responds with datapoints

### Screenshot of OpenShift metrics console
<img width="3220" height="1747" alt="image" src="https://github.com/user-attachments/assets/1b4c745b-e8c2-414b-8d59-f375fd33708e" />

🤖 Generated with [Claude Code](https://claude.ai/claude-code)